### PR TITLE
Correct 2-inputs function

### DIFF
--- a/tests/onnx2circom/test_onnx_to_circom.py
+++ b/tests/onnx2circom/test_onnx_to_circom.py
@@ -1,21 +1,7 @@
-import json
-import os
-from pathlib import Path
-from typing import Type
-
 import torch
 import torch.nn as nn
 
-from zkstats.onnx2circom import onnx_to_circom
-from zkstats.arithc_to_bristol import parse_arithc_json
-from zkstats.backends.mpspdz import generate_mpspdz_circuit, run_mpspdz_circuit
-
-from .utils import run_torch_model, torch_model_to_onnx
-
-
-# NOTE: Change the path to your own path
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
-MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
+from .utils import compile_and_check
 
 
 def test_onnx_to_circom(tmp_path):
@@ -30,83 +16,4 @@ def test_onnx_to_circom(tmp_path):
             l = torch.log(x)  # 5,3,3
             return m*s+l #773, 771, 771
 
-
     compile_and_check(Model, data, tmp_path)
-
-def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path: Path):
-    # output_path = tmp_path
-    # Don't use tmp_path for now for easier debugging
-    # So you should see all generated files in `output_path`
-    output_path = Path(__file__).parent / 'out'
-    print(f"!@# {output_path=}")
-    output_path.mkdir(parents=True, exist_ok=True)
-    onnx_path = output_path / 'model.onnx'
-    model_name = onnx_path.stem
-    keras_path = onnx_path.parent / f"{model_name}.keras"
-    assert onnx_path.stem == keras_path.stem
-    print(f"!@# {keras_path=}")
-    circom_path = output_path / f"{model_name}.circom"
-    print(f"!@# {circom_path=}")
-
-    print("Running torch model...")
-    output_torch = run_torch_model(model_type, data)
-    print("!@# output_torch=", output_torch)
-
-    print("Transforming torch model to onnx...")
-    torch_model_to_onnx(model_type, data, onnx_path)
-    assert onnx_path.exists() is True, f"The output file {onnx_path} does not exist."
-    print("Transforming onnx model to circom...")
-    onnx_to_circom(onnx_path, circom_path)
-    assert circom_path.exists() is True, f"The output file {circom_path} does not exist."
-
-    arithc_path = output_path / f"{model_name}.json"
-    # Compile with circom-2-arithc compiler
-    code = os.system(f"cd {CIRCOM_2_ARITHC_PROJECT_ROOT} && ./target/release/circom --input {circom_path} --output {output_path}")
-    if code != 0:
-        raise ValueError(f"Failed to compile circom. Error code: {code}")
-    arithc_path = output_path / f"{model_name}.json"
-    assert arithc_path.exists() is True, f"The output file {arithc_path} does not exist."
-
-    print("!@# circom_path=", circom_path)
-    print("!@# arithc_path=", arithc_path)
-
-    bristol_path = output_path / f"{model_name}.txt"
-    circuit_info_path = output_path / f"{model_name}.circuit_info.json"
-    parse_arithc_json(arithc_path, bristol_path, circuit_info_path)
-    assert bristol_path.exists() is True, f"The output file {bristol_path} does not exist."
-    assert circuit_info_path.exists() is True, f"The output file {circuit_info_path} does not exist."
-    print("!@# bristol_path=", bristol_path)
-    print("!@# circuit_info_path=", circuit_info_path)
-
-    # Mark every input as from 0
-    with open(circuit_info_path, 'r') as f:
-        circuit_info = json.load(f)
-    input_name_to_wire_index = circuit_info['input_name_to_wire_index']
-    input_names = list(input_name_to_wire_index.keys())
-    print("!@# input_names=", input_names)
-
-    # TODO: This should come from users. Here we just set up a config json
-    # for convenience (which input is from which party). Now just put every input to party 0.
-    # Assume the input data is a 1-d tensor
-    user_config_path = MP_SPDZ_PROJECT_ROOT / f"Configs/{model_name}.json"
-    user_config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(user_config_path, 'w') as f:
-        json.dump({"inputs_from": {
-            "0": input_names,
-        }}, f, indent=4)
-
-    print("!@# user_config_path=", user_config_path)
-
-    # Prepare data for party 0
-    data_list = data.reshape(-1)
-    input_0_path = MP_SPDZ_PROJECT_ROOT / 'Player-Data/Input-P0-0'
-    input_0_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(input_0_path, 'w') as f:
-        # TODO: change int to float
-        f.write(' '.join([str(int(x)) for x in data_list.tolist()]))
-
-    # Run MP-SPDZ
-    mpc_circuit_path = generate_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, bristol_path, circuit_info_path, user_config_path)
-    print(f"Running mp-spdz circuit {mpc_circuit_path}...")
-    run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpc_circuit_path)
-    # TODO: parse output from MP-SPDZ and compare with torch output

--- a/tests/onnx2circom/test_onnx_to_circom.py
+++ b/tests/onnx2circom/test_onnx_to_circom.py
@@ -14,8 +14,8 @@ from .utils import run_torch_model, torch_model_to_onnx
 
 
 # NOTE: Change the path to your own path
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/jernkun/Desktop/circom-2-arithc')
-MP_SPDZ_PROJECT_ROOT = Path('/Users/jernkun/Desktop/MP-SPDZ')
+CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
+MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
 
 
 def test_onnx_to_circom(tmp_path):

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -18,17 +18,38 @@ CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/jernkun/Desktop/circom-2-arithc')
 MP_SPDZ_PROJECT_ROOT = Path('/Users/jernkun/Desktop/MP-SPDZ')
 
 
-def test_onnx_to_circom(tmp_path):
+def test_two_inputs(tmp_path):
     data = torch.tensor(
         [32, 8, 8],
         dtype = torch.float32,
     ).reshape(1, -1, 1)
     class Model(nn.Module):
         def forward(self, x):
-            m = torch.mean(x)  # 16
-            s = torch.sum(x)  # 48
-            l = torch.log(x)  # 5,3,3
-            return m*s+l #773, 771, 771
+            return x-torch.log(x)
+            # All tests below already pass
+            return x+4
+            return 4+x
+            return x-4
+            return 4-x
+            return x+torch.log(x)
+            return torch.log(x)+x
+            return x-torch.log(x)
+            return torch.log(x)-x
+            return torch.mean(x)+4
+            return 4+torch.mean(x)
+            return torch.mean(x)-4
+            return 4-torch.mean(x)
+            return torch.mean(x)+4
+            return torch.mean(x)+torch.sum(x)
+            return torch.mean(x)-torch.sum(x)
+            return torch.mean(x)+x
+            return x+torch.mean(x)
+            return torch.mean(x)-x
+            return x-torch.mean(x)
+            return torch.mean(x)+torch.log(x)
+            return torch.log(x)+torch.mean(x)
+            return torch.mean(x)-torch.log(x)
+            return torch.log(x)-torch.mean(x)
 
 
     compile_and_check(Model, data, tmp_path)

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -14,8 +14,8 @@ from .utils import run_torch_model, torch_model_to_onnx
 
 
 # NOTE: Change the path to your own path
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/jernkun/Desktop/circom-2-arithc')
-MP_SPDZ_PROJECT_ROOT = Path('/Users/jernkun/Desktop/MP-SPDZ')
+CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
+MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
 
 
 def test_two_inputs(tmp_path):

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -1,133 +1,45 @@
-import json
-import os
-from pathlib import Path
-from typing import Type
-
 import torch
 import torch.nn as nn
 
-from zkstats.onnx2circom import onnx_to_circom
-from zkstats.arithc_to_bristol import parse_arithc_json
-from zkstats.backends.mpspdz import generate_mpspdz_circuit, run_mpspdz_circuit
+import pytest
 
-from .utils import run_torch_model, torch_model_to_onnx
+from .utils import compile_and_check
 
 
-# NOTE: Change the path to your own path
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
-MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
-
-
-def test_two_inputs(tmp_path):
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(lambda x: x + 4, id="x + 4"),
+        pytest.param(lambda x: 4 + x, id="4 + x"),
+        pytest.param(lambda x: x - 4, id="x - 4"),
+        pytest.param(lambda x: 4 - x, id="4 - x"),
+        pytest.param(lambda x: torch.mean(x) + 4, id="mean(x) + 4"),
+        pytest.param(lambda x: 4 + torch.mean(x), id="4 + mean(x)"),
+        pytest.param(lambda x: torch.mean(x) - 4, id="mean(x) - 4"),
+        pytest.param(lambda x: 4 - torch.mean(x), id="4 - mean(x)"),
+        pytest.param(lambda x: torch.mean(x) + torch.sum(x), id="mean(x) + sum(x)"),
+        pytest.param(lambda x: torch.mean(x) - torch.sum(x), id="mean(x) - sum(x)"),
+        pytest.param(lambda x: torch.mean(x) + x, id="mean(x) + x"),
+        pytest.param(lambda x: x + torch.mean(x), id="x + mean(x)"),
+        pytest.param(lambda x: torch.mean(x) - x, id="mean(x) - x"),
+        pytest.param(lambda x: x - torch.mean(x), id="x - mean(x)"),
+        # `log` is slower. We can test non-slow ones with `pytest -m "not slow"`
+        pytest.param(lambda x: x + torch.log(x), id="x + log(x)"),
+        pytest.param(lambda x: torch.log(x) + x, id="log(x) + x"),
+        pytest.param(lambda x: x - torch.log(x), id="x - log(x)"),
+        pytest.param(lambda x: torch.log(x) - x, id="log(x) - x"),
+        pytest.param(lambda x: torch.mean(x) + torch.log(x), id="mean(x) + log(x)"),
+        pytest.param(lambda x: torch.log(x) + torch.mean(x), id="log(x) + mean(x)"),
+        pytest.param(lambda x: torch.mean(x) - torch.log(x), id="mean(x) - log(x)"),
+    ]
+)
+def test_two_inputs(func, tmp_path):
     data = torch.tensor(
         [32, 8, 8],
         dtype = torch.float32,
     ).reshape(1, -1, 1)
     class Model(nn.Module):
         def forward(self, x):
-            return x-torch.log(x)
-            # All tests below already pass
-            return x+4
-            return 4+x
-            return x-4
-            return 4-x
-            return x+torch.log(x)
-            return torch.log(x)+x
-            return x-torch.log(x)
-            return torch.log(x)-x
-            return torch.mean(x)+4
-            return 4+torch.mean(x)
-            return torch.mean(x)-4
-            return 4-torch.mean(x)
-            return torch.mean(x)+4
-            return torch.mean(x)+torch.sum(x)
-            return torch.mean(x)-torch.sum(x)
-            return torch.mean(x)+x
-            return x+torch.mean(x)
-            return torch.mean(x)-x
-            return x-torch.mean(x)
-            return torch.mean(x)+torch.log(x)
-            return torch.log(x)+torch.mean(x)
-            return torch.mean(x)-torch.log(x)
-            return torch.log(x)-torch.mean(x)
-
+            return func(x)
 
     compile_and_check(Model, data, tmp_path)
-
-def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path: Path):
-    # output_path = tmp_path
-    # Don't use tmp_path for now for easier debugging
-    # So you should see all generated files in `output_path`
-    output_path = Path(__file__).parent / 'out'
-    print(f"!@# {output_path=}")
-    output_path.mkdir(parents=True, exist_ok=True)
-    onnx_path = output_path / 'model.onnx'
-    model_name = onnx_path.stem
-    keras_path = onnx_path.parent / f"{model_name}.keras"
-    assert onnx_path.stem == keras_path.stem
-    print(f"!@# {keras_path=}")
-    circom_path = output_path / f"{model_name}.circom"
-    print(f"!@# {circom_path=}")
-
-    print("Running torch model...")
-    output_torch = run_torch_model(model_type, data)
-    print("!@# output_torch=", output_torch)
-
-    print("Transforming torch model to onnx...")
-    torch_model_to_onnx(model_type, data, onnx_path)
-    assert onnx_path.exists() is True, f"The output file {onnx_path} does not exist."
-    print("Transforming onnx model to circom...")
-    onnx_to_circom(onnx_path, circom_path)
-    assert circom_path.exists() is True, f"The output file {circom_path} does not exist."
-
-    arithc_path = output_path / f"{model_name}.json"
-    # Compile with circom-2-arithc compiler
-    code = os.system(f"cd {CIRCOM_2_ARITHC_PROJECT_ROOT} && ./target/release/circom --input {circom_path} --output {output_path}")
-    if code != 0:
-        raise ValueError(f"Failed to compile circom. Error code: {code}")
-    arithc_path = output_path / f"{model_name}.json"
-    assert arithc_path.exists() is True, f"The output file {arithc_path} does not exist."
-
-    print("!@# circom_path=", circom_path)
-    print("!@# arithc_path=", arithc_path)
-
-    bristol_path = output_path / f"{model_name}.txt"
-    circuit_info_path = output_path / f"{model_name}.circuit_info.json"
-    parse_arithc_json(arithc_path, bristol_path, circuit_info_path)
-    assert bristol_path.exists() is True, f"The output file {bristol_path} does not exist."
-    assert circuit_info_path.exists() is True, f"The output file {circuit_info_path} does not exist."
-    print("!@# bristol_path=", bristol_path)
-    print("!@# circuit_info_path=", circuit_info_path)
-
-    # Mark every input as from 0
-    with open(circuit_info_path, 'r') as f:
-        circuit_info = json.load(f)
-    input_name_to_wire_index = circuit_info['input_name_to_wire_index']
-    input_names = list(input_name_to_wire_index.keys())
-    print("!@# input_names=", input_names)
-
-    # TODO: This should come from users. Here we just set up a config json
-    # for convenience (which input is from which party). Now just put every input to party 0.
-    # Assume the input data is a 1-d tensor
-    user_config_path = MP_SPDZ_PROJECT_ROOT / f"Configs/{model_name}.json"
-    user_config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(user_config_path, 'w') as f:
-        json.dump({"inputs_from": {
-            "0": input_names,
-        }}, f, indent=4)
-
-    print("!@# user_config_path=", user_config_path)
-
-    # Prepare data for party 0
-    data_list = data.reshape(-1)
-    input_0_path = MP_SPDZ_PROJECT_ROOT / 'Player-Data/Input-P0-0'
-    input_0_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(input_0_path, 'w') as f:
-        # TODO: change int to float
-        f.write(' '.join([str(int(x)) for x in data_list.tolist()]))
-
-    # Run MP-SPDZ
-    mpc_circuit_path = generate_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, bristol_path, circuit_info_path, user_config_path)
-    print(f"Running mp-spdz circuit {mpc_circuit_path}...")
-    run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpc_circuit_path)
-    # TODO: parse output from MP-SPDZ and compare with torch output

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -3,6 +3,136 @@ from typing import Type
 
 import torch
 import torch.nn as nn
+import json
+import os
+
+
+from zkstats.onnx2circom import onnx_to_circom
+from zkstats.arithc_to_bristol import parse_arithc_json
+from zkstats.backends.mpspdz import generate_mpspdz_circuit, generate_mpspdz_inputs_for_party, run_mpspdz_circuit
+
+
+CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
+MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
+
+
+def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path: Path):
+    # output_path = tmp_path
+    # Don't use tmp_path for now for easier debugging
+    # So you should see all generated files in `output_path`
+    output_path = Path(__file__).parent / 'out'
+    print(f"!@# {output_path=}")
+    output_path.mkdir(parents=True, exist_ok=True)
+    onnx_path = output_path / 'model.onnx'
+    model_name = onnx_path.stem
+    keras_path = onnx_path.parent / f"{model_name}.keras"
+    assert onnx_path.stem == keras_path.stem
+    print(f"!@# {keras_path=}")
+    circom_path = output_path / f"{model_name}.circom"
+    print(f"!@# {circom_path=}")
+
+    print("Running torch model...")
+    output_torch = run_torch_model(model_type, data)
+    print("!@# output_torch=", output_torch)
+
+    print("Transforming torch model to onnx...")
+    torch_model_to_onnx(model_type, data, onnx_path)
+    assert onnx_path.exists() is True, f"The output file {onnx_path} does not exist."
+    print("Transforming onnx model to circom...")
+    onnx_to_circom(onnx_path, circom_path)
+    assert circom_path.exists() is True, f"The output file {circom_path} does not exist."
+
+    arithc_path = output_path / f"{model_name}.json"
+    # Compile with circom-2-arithc compiler
+    code = os.system(f"cd {CIRCOM_2_ARITHC_PROJECT_ROOT} && ./target/release/circom --input {circom_path} --output {output_path}")
+    if code != 0:
+        raise ValueError(f"Failed to compile circom. Error code: {code}")
+    arithc_path = output_path / f"{model_name}.json"
+    assert arithc_path.exists() is True, f"The output file {arithc_path} does not exist."
+
+    print("!@# circom_path=", circom_path)
+    print("!@# arithc_path=", arithc_path)
+
+    bristol_path = output_path / f"{model_name}.txt"
+    circuit_info_path = output_path / f"{model_name}.circuit_info.json"
+    parse_arithc_json(arithc_path, bristol_path, circuit_info_path)
+    assert bristol_path.exists() is True, f"The output file {bristol_path} does not exist."
+    assert circuit_info_path.exists() is True, f"The output file {circuit_info_path} does not exist."
+    print("!@# bristol_path=", bristol_path)
+    print("!@# circuit_info_path=", circuit_info_path)
+
+    # Mark every input as from 0
+    with open(circuit_info_path, 'r') as f:
+        circuit_info = json.load(f)
+    input_name_to_wire_index = circuit_info['input_name_to_wire_index']
+    output_name_to_wire_index = circuit_info['output_name_to_wire_index']
+    input_names = list(input_name_to_wire_index.keys())
+    output_names = list(output_name_to_wire_index.keys())
+    print("!@# input_names=", input_names)
+
+    num_parties = 2
+    # TODO: This should come from users. Here we just set up a config json
+    # for convenience (which input is from which party). Now just put every input to party 0.
+    # Assume the input data is a 1-d tensor
+    mpc_settings_path = output_path / f"{model_name}.mpc_settings.json"
+    mpc_settings_path.parent.mkdir(parents=True, exist_ok=True)
+    # party 0 is alice, having input a, and output a_add_b, a_mul_c are revealed to
+    # party 1 is bob, having input b, and output a_add_b, a_mul_c are revealed to
+    # [
+    #     {
+    #         "name": "alice",
+    #         "inputs": ["a"],
+    #         "outputs": ["a_add_b", "a_mul_c"]
+    #     },
+    #     {
+    #         "name": "bob",
+    #         "inputs": ["b"],
+    #         "outputs": ["a_add_b", "a_mul_c"]
+    #     }
+    # ]
+    with open(mpc_settings_path, 'w') as f:
+        json.dump([
+            {
+                "name": "alice",
+                "inputs": input_names,  # All inputs are from party 0
+                "outputs": output_names,  # Party 0 can see all outputs
+            },
+            {
+                "name": "bob",
+                "inputs": [],  # No input is from party 1
+                "outputs": output_names,  # Party 1 can see all outputs
+            }
+        ], f, indent=4)
+
+    print("!@# mpc_settings_path=", mpc_settings_path)
+
+    # Prepare data for party 0
+    data_list = data.reshape(-1)
+    input_paths = [output_path / f"{model_name}_party_{i}.inputs.json" for i in range(num_parties)]
+    input_paths[0].parent.mkdir(parents=True, exist_ok=True)
+    with open(input_paths[0], 'w') as f:
+        json.dump({
+            name: int(x) for name, x in zip(input_names, data_list.tolist())
+        }, f, indent=4)
+    # input 1 is empty
+    with open(input_paths[1], 'w') as f:
+        json.dump({}, f)
+
+    # Run MP-SPDZ
+    mpspdz_circuit_path = generate_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, bristol_path, circuit_info_path, mpc_settings_path)
+    for party in range(num_parties):
+        input_json_for_party_path = output_path / f"{model_name}_party_{party}.inputs.json"
+        mpspdz_input_path = generate_mpspdz_inputs_for_party(
+            MP_SPDZ_PROJECT_ROOT,
+            party,
+            input_json_for_party_path,
+            circuit_info_path,
+            mpc_settings_path,
+        )
+        print(f"Party {party} input path: {mpspdz_input_path}")
+    print(f"Running mp-spdz circuit {mpspdz_circuit_path}...")
+    # TODO: parse output from MP-SPDZ and compare with torch output
+    run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
 
 
 def run_torch_model(model_type: Type[nn.Module], data: torch.Tensor) -> torch.Tensor:

--- a/zkstats/backends/mpspdz.py
+++ b/zkstats/backends/mpspdz.py
@@ -1,6 +1,35 @@
+from dataclasses import dataclass
+from enum import Enum
 import json
 import os
 from pathlib import Path
+
+
+class AGateType(Enum):
+    ADD = 'AAdd'
+    DIV = 'ADiv'
+    EQ = 'AEq'
+    GT = 'AGt'
+    GEQ = 'AGEq'
+    LT = 'ALt'
+    LEQ = 'ALEq'
+    MUL = 'AMul'
+    NEQ = 'ANeq'
+    SUB = 'ASub'
+
+
+MAP_GATE_TYPE_TO_OPERATOR_STR = {
+    AGateType.ADD: '+',
+    AGateType.MUL: '*',
+    AGateType.DIV: '/',
+    AGateType.LT: '<',
+    AGateType.SUB: '-',
+    AGateType.EQ: '==',
+    AGateType.NEQ: '!=',
+    AGateType.GT: '>',
+    AGateType.GEQ: '>=',
+    AGateType.LEQ: '<=',
+}
 
 
 MPSPDZ_CIRCUIT_RELATIVE_PATH = Path('Programs/Source')
@@ -26,8 +55,20 @@ def generate_mpspdz_circuit(
     mpspdz_project_root: Path,
     arith_circuit_path: Path,
     circuit_info_path: Path,
-    input_config_path: Path,
+    mpc_settings_path: Path,
 ) -> Path:
+    '''
+    Generate the MP-SPDZ circuit code that can be run by MP-SPDZ.
+
+    Steps:
+    1. Read the arithmetic circuit file to get the gates
+    2. Read the circuit info file to get the input/output wire mapping
+    3. Read the input config file to get which party inputs should be read from
+    4. Generate the MP-SPDZ from the inputs above. The code should:
+        4.1. Initialize a `wires` list with input wires filled in: if a wire is a constant, fill it in directly. if a wire is an input, fill in which party this input comes from
+        4.2. Translate the gates into corresponding operations in MP-SPDZ
+        4.3. Print the outputs
+    '''
     # {
     #   "input_name_to_wire_index": { "a": 1, "b": 0, "c": 2},
     #   "constants": {"d": {"value": 50, "wire_index": 3}},
@@ -39,54 +80,187 @@ def generate_mpspdz_circuit(
     input_name_to_wire_index = {k: int(v) for k, v in raw['input_name_to_wire_index'].items()}
     constants: dict[str, dict[str, int]] = raw['constants']
     output_name_to_wire_index = {k: int(v) for k, v in raw['output_name_to_wire_index'].items()}
-    # {
-    #     "inputs_from": {
-    #         "0": ["a", "b"],
-    #         "1": ["c"]
+    # [
+    #     {
+    #         "name": "alice",
+    #         "inputs": ["a"],
+    #         "outputs": ["a_add_b", "a_mul_c"]
+    #     },
+    #     {
+    #         "name": "bob",
+    #         "inputs": ["b"],
+    #         "outputs": ["a_add_b", "a_mul_c"]
     #     }
-    # }
-    with open(input_config_path, 'r') as f:
-        input_config = json.load(f)
-    inputs_from: dict[str, list[str]] = input_config['inputs_from']
+    # ]
+    with open(mpc_settings_path, 'r') as f:
+        mpc_settings = json.load(f)
+
+    # Read number of wires from the bristol circuit file
+    # A bristol circuit file looks like this:
+    # 2 5
+    # 3 1 1 1
+    # 2 1 1
+    #
+    # 2 1 1 0 3 AAdd
+    # 2 1 1 2 4 AMul
+    # """
+
+    # Each gate line looks like this: '2 1 1 0 3 AAdd'
+    @dataclass(frozen=True)
+    class Gate:
+        num_inputs: int
+        num_outputs: int
+        gate_type: AGateType
+        inputs_wires: list[int]
+        output_wire: int
+    with open(arith_circuit_path, 'r') as f:
+        first_line = next(f)
+        num_gates, num_wires = map(int, first_line.split())
+        second_line = next(f)
+        num_inputs = int(second_line.split()[0])
+        third_line = next(f)
+        num_outputs = int(third_line.split()[0])
+        # Skip the next line
+        next(f)
+
+        # Read the gate lines
+        gates: list[Gate] = []
+        for line in f:
+            line = line.split()
+            num_inputs = int(line[0])
+            num_outputs = int(line[1])
+            inputs_wires = [int(x) for x in line[2:2+num_inputs]]
+            # Support 2 inputs only for now
+            assert num_inputs == 2 and num_inputs == len(inputs_wires)
+            output_wires = list(map(int, line[2+num_inputs:2+num_inputs+num_outputs]))
+            output_wire = output_wires[0]
+            # Support 1 output only for now
+            assert num_outputs == 1 and num_outputs == len(output_wires)
+            gate_type = AGateType(line[2+num_inputs+num_outputs])
+            gates.append(Gate(num_inputs, num_outputs, gate_type, inputs_wires, output_wire))
+    assert len(gates) == num_gates
 
     # Make inputs to circuit (not wires!!) from the user config
-    # The inputs order will be [constant1, constant2, ..., party_0_input1, party_0_input2, ..., party_1_input1, ...]
-    inputs_str_list = []
-    wire_index_for_input = []
+    # Initialize a list `inputs` with `num_wires` with value=None
+    inputs_str_list = [None] * num_wires
+    print_outputs_str_list = []
+    # Fill in the constants
     for name, o in constants.items():
-        value = o['value']
-        wire_index = o['wire_index']
-        wire_index_for_input.append(wire_index)
-        inputs_str_list.append(f'cint({value})')
-    for party, inputs in inputs_from.items():
-        for name in inputs:
-            wire_index = input_name_to_wire_index[name]
-            wire_index_for_input.append(wire_index)
-            inputs_str_list.append(f'sint.get_input_from({party})')
+        value = int(o['value'])
+        # descaled_value = value / (10 ** scale)
+        wire_index = int(o['wire_index'])
+        # Sanity check
+        if inputs_str_list[wire_index] is not None:
+            raise ValueError(f"Wire index {wire_index} is already filled in: {inputs_str_list[wire_index]=}")
+        inputs_str_list[wire_index] = f'cfix({value})'
+    for party_index, party_settings in enumerate(mpc_settings):
+        # Fill in the inputs from the parties
+        for input_name in party_settings['inputs']:
+            wire_index = int(input_name_to_wire_index[input_name])
+            # Sanity check
+            if inputs_str_list[wire_index] is not None:
+                raise ValueError(f"Wire index {wire_index} is already filled in: {inputs_str_list[wire_index]=}")
+            inputs_str_list[wire_index] = f'sfix.get_input_from({party_index})'
+        # Fill in the outputs
+        for output_name in party_settings['outputs']:
+            wire_index = int(output_name_to_wire_index[output_name])
+            print_outputs_str_list.append(
+                f"print_ln_to({party_index}, 'outputs[{len(print_outputs_str_list)}]: {output_name}=%s', wires[{wire_index}].reveal_to({party_index}))"
+            )
+
+
+    # Replace all `None` with str `'None'`
+    inputs_str_list = [x if x is not None else 'None' for x in inputs_str_list]
 
     #
     # Generate the circuit code
     #
     inputs_str = '[' + ', '.join(inputs_str_list) + ']'
+
+    # Translate bristol gates to MP-SPDZ operations
+    # E.g.
+    # '2 1 1 0 2 AAdd' in bristol
+    #   is translated to
+    # 'wires[2] = wires[1] + wires[0]' in MP-SPDZ
+    gates_str_list = []
+    for gate in gates:
+        gate_str = ''
+        if gate.gate_type not in MAP_GATE_TYPE_TO_OPERATOR_STR:
+            raise ValueError(f"Gate type {gate.gate_type} is not supported")
+        else:
+            operator_str = MAP_GATE_TYPE_TO_OPERATOR_STR[gate.gate_type]
+            gate_str = f'wires[{gate.output_wire}] = wires[{gate.inputs_wires[0]}] {operator_str} wires[{gate.inputs_wires[1]}]'
+        gates_str_list.append(gate_str)
+    gates_str = '\n'.join(gates_str_list)
+
     # For outputs, should print the actual output names, and
     # lines are ordered by actual output wire index since it's guaranteed the order
     # E.g.
     # print_ln('outputs[0]: a_add_b=%s', outputs[0].reveal())
     # print_ln('outputs[1]: a_mul_c=%s', outputs[1].reveal())
-    print_outputs_str_list = [
-        f"print_ln('outputs[{i}]: {output_name}=%s', outputs[{output_name_to_wire_index[output_name]}].reveal())"
-        for i, output_name in enumerate(output_name_to_wire_index.keys())
-    ]
+    # print_outputs_str_list = [
+    #     f"print_ln('outputs[{i}]: {output_name}=%s', wires[{output_name_to_wire_index[output_name]}].reveal())"
+    #     for i, output_name in enumerate(output_name_to_wire_index.keys())
+    # ]
     print_outputs_str = '\n'.join(print_outputs_str_list)
-    circuit = f"""from circuit_arith import Circuit
-circuit = Circuit('{arith_circuit_path}', {wire_index_for_input})
-inputs = {inputs_str}
-outputs = circuit(inputs)
+
+    circuit_code = f"""wires = {inputs_str}
+{gates_str}
 # Print outputs
 {print_outputs_str}
 """
     circuit_name = arith_circuit_path.stem
     out_mpc_path = mpspdz_project_root / MPSPDZ_CIRCUIT_RELATIVE_PATH / f"{circuit_name}.mpc"
     with open(out_mpc_path, 'w') as f:
-        f.write(circuit)
+        f.write(circuit_code)
     return out_mpc_path
+
+
+def generate_mpspdz_inputs_for_party(
+    mpspdz_project_root: Path,
+    party: int,
+    input_json_for_party_path: Path,
+    circuit_info_path: Path,
+    mpc_settings_path: Path,
+):
+    '''
+    Generate MP-SPDZ circuit inputs for a party.
+
+    For each party, we need to translate `party_{i}.inputs.json` to an input file for MP-SPDZ according to their inputs' wire order
+    - The input file format of MP-SPDZ is `input0 input1 input2 ... inputN`. Each value is separated with a space
+    - This order is determined by the position (index) of the inputs in the MP-SPDZ wires
+        - For example, the actual wires in the generated MP-SPDZ circuit might look like this:
+            `[cfix(123), sfix.get_input_from(0), sfix.get_input_from(1), cfix(456), sfix.get_input_from(0), ...]`
+            - For party `0`, its MP-SPDZ inputs file should contain two values: one is for the first `sfix.get_input_from(0)`
+                and the other is for the second `sfix.get_input_from(0)`.
+        - This order can be obtained by sorting the `input_name_to_wire_index` by the wire index
+    '''
+
+    # Read inputs value from user provided input files
+    with open(input_json_for_party_path) as f:
+        input_values_for_party_json = json.load(f)
+
+    with open(mpc_settings_path, 'r') as f:
+        mpc_settings = json.load(f)
+    inputs_from: dict[str, int] = {}
+    for party_index, party_settings in enumerate(mpc_settings):
+        for input_name in party_settings['inputs']:
+            inputs_from[input_name] = int(party_index)
+
+    with open(circuit_info_path, 'r') as f:
+        circuit_info = json.load(f)
+        input_name_to_wire_index = circuit_info['input_name_to_wire_index']
+
+    wire_to_name_sorted = sorted(input_name_to_wire_index.items(), key=lambda x: x[1])
+    wire_value_in_order_for_mpsdz = []
+    for wire_name, wire_index in wire_to_name_sorted:
+        wire_from_party = int(inputs_from[wire_name])
+        # For the current party, we only care about the inputs from itself
+        if wire_from_party == party:
+            wire_value = input_values_for_party_json[wire_name]
+            wire_value_in_order_for_mpsdz.append(wire_value)
+    # Write these ordered wire inputs for mp-spdz usage
+    input_file_for_party_mpspdz = mpspdz_project_root / f"Player-Data/Input-P{party}-0"
+    with open(input_file_for_party_mpspdz, 'w') as f:
+        f.write(" ".join(map(str, wire_value_in_order_for_mpsdz)))
+    return input_file_for_party_mpspdz

--- a/zkstats/onnx2circom/__init__.py
+++ b/zkstats/onnx2circom/__init__.py
@@ -33,14 +33,14 @@ def keras_to_circom(keras_path: Path, generated_circom_path: Path):
     #     # TODO: should we skip them?
     #     skips=['util.circom', 'circomlib-matrix', 'circomlib', 'crypto'],
     # )
-    circom.file_parse(MPC_CIRCOM_PATH)
+    templates = circom.file_parse(MPC_CIRCOM_PATH)
     # transpiler.transpile(args['<model.h5>'], args['--output'], args['--raw'], args['--decimals'])
     # keras2circom_output_dir = Path(tempfile.mkdtemp())
     keras2circom_output_dir = generated_circom_path.parent
     transpiler.transpile(
+        templates,
         str(keras_path),
         str(keras2circom_output_dir),
-        dec=18,  # TODO: decimal. Now it's the default value. We can pick up a suitable value
     )
     generated_circom_original = keras2circom_output_dir / f"circuit.circom"
     # Copy the generated circom file to the target path

--- a/zkstats/onnx2circom/keras2circom/keras2circom/circom.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/circom.py
@@ -8,10 +8,6 @@ from dataclasses import dataclass
 
 import re
 
-templates: typing.Dict[str, 'Template'] = {
-
-}
-
 
 @dataclass
 class Template:
@@ -50,6 +46,7 @@ def file_parse(fpath):
     # !@# file_parse: sig=('output', 'out', '[1]')
     # !@# file_parse: infos=[['in'], [2], ['out'], [1]]
     # !@# file_parse: args=['nInputs']
+    templates: typing.Dict[str, Template] = {}
     funcs = re.findall('template (\w+) ?\((.*?)\) ?\{(.*?)\}', lines)
     for func in funcs:
         op_name = func[0].strip()
@@ -94,6 +91,7 @@ def file_parse(fpath):
             output_names=infos[2],
             output_dims=infos[3],
         )
+    return templates
 
 
 def dir_parse(dir_path, skips=[]):

--- a/zkstats/onnx2circom/keras2circom/keras2circom/model.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/model.py
@@ -15,13 +15,23 @@ class KerasTensor(typing.Protocol):
     name: str
 
 
+@dataclass(frozen=True)
+class Input:
+    is_constant: bool
+    shape: typing.Sequence[int]
+    # If it's a constant, name is None. Else, it's the name of the input in keras model.
+    name: typing.Optional[str]
+    # If it's a constant, value is the value of the constant. Else, it's None
+    value: typing.Optional[float]
+
+
 # read each layer in a model and convert it to a class called Layer
 @dataclass
 class Layer:
     ''' A single layer in a Keras model. '''
     op: str
     name: str
-    inputs: list[KerasTensor]
+    inputs: list[Input]
     outputs: list[KerasTensor]
     config: dict
 
@@ -29,19 +39,49 @@ class Layer:
         self.op = layer.__class__.__name__
         self.name = layer.name
         # Always convert to list for easier handling. Doing this since if there is only one input, it is not a list in keras layer
-        self.inputs = layer.input if isinstance(layer.input, list) else [layer.input]
+        _inputs = layer.input if isinstance(layer.input, list) else [layer.input]
         # Always convert to list for easier handling. Doing this since if there is only one output, it is not a list in keras layer
         self.outputs = layer.output if isinstance(layer.output, list) else [layer.output]
-        self.config = layer.get_config()
-        self.full_inputs = []
-        list_inputs =  layer.get_config()['node_inputs']
+        _config = layer.get_config()
+        self.config = _config
+        self.inputs = []
+        list_inputs = _config['node_inputs']
+
         index = 0
-        for ele in list_inputs:
-            config_ele = layer.get_config()['tensor_grap'][ele]
-            if isinstance(config_ele, dict) and config_ele["class_name"]=='__keras_tensor__':
-                config_ele['name'] = self.inputs[index].name
-                index+=1
-            self.full_inputs.append(config_ele)
+        for ele_name in list_inputs:
+            # non-constant: {'class_name': '__keras_tensor__', 'config': {'shape': [1, 3, 1], 'dtype': 'float32', 'keras_history': ['input_layer', 0, 0]}, 'name': 'input_layer'},
+            # constant: 3.0
+            config_ele = _config['tensor_grap'][ele_name]
+            # it's not a constant, add the name of the input
+            is_non_constant = isinstance(config_ele, dict) and config_ele["class_name"]=='__keras_tensor__'
+            # if it's constant, get the shape from non-constant input
+            if is_non_constant:
+                name = _inputs[index].name
+                value = None
+                input_shape = tuple(config_ele['config']['shape'])
+                if input_shape == ():
+                    # if there are more than 1 inputs like `TFAdd`, we need to get the shape of the other input
+                    if len(_inputs)==2 and len(_inputs[1-index].shape)>=2:
+                        input_shape = (_inputs[1-index]).shape[:-1]
+                    else:
+                        input_shape =(1,1)
+                index += 1
+            # it's constant. assume it's a float
+            else:
+                name = None
+                value = float(config_ele)
+                if len(_inputs)>0 and len(_inputs[0].shape)>=2:
+                    input_shape = (_inputs[0]).shape[:-1]
+                else:
+                    input_shape =(1,1)
+            self.inputs.append(
+                Input(
+                    is_constant=not is_non_constant,
+                    shape=input_shape,
+                    name=name,
+                    value=value,
+                )
+            )
 
 
 class Model:

--- a/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
@@ -1,7 +1,7 @@
 import os
 import typing
 
-from .circom import templates
+from .circom import Template
 from .model import Layer, Model
 
 
@@ -73,65 +73,29 @@ def get_component_args_values(layer: Layer) -> typing.Dict[str, typing.Any]:
     else:
         num_elements_in_input_0 = input_0_shape[0]
 
-    # NOTE: Add more cases here if new circom components are supported
-    if layer.op == TFReduceSum.__name__:
-        return {'nInputs': num_elements_in_input_0}
-    if layer.op == TFReduceMean.__name__:
-        return {'nInputs': num_elements_in_input_0}
-    if layer.op == TFAdd.__name__:
-        if len(inputs)==2:
-            input_1 = inputs[1]
-            input_1_shape = get_effective_shape(input_1.shape)
-            if len(input_1_shape) == 0:
-                num_elements_in_input_1 = 1
-            # Else, the number of elements in the input tensor is the first dimension
-            # E.g. input_0.shape = (1, 2, 1), input_0_shape=(2, 1), num_elements_in_input_0=2
-            else:
-                num_elements_in_input_1 = input_1_shape[0]
-            return {'nElements': max(num_elements_in_input_0, num_elements_in_input_1)}
-        return {'nElements': num_elements_in_input_0}
-    if layer.op == TFSub.__name__:
-        if len(inputs)==2:
-            input_1 = inputs[1]
-            input_1_shape = get_effective_shape(input_1.shape)
-            if len(input_1_shape) == 0:
-                num_elements_in_input_1 = 1
-            # Else, the number of elements in the input tensor is the first dimension
-            # E.g. input_0.shape = (1, 2, 1), input_0_shape=(2, 1), num_elements_in_input_0=2
-            else:
-                num_elements_in_input_1 = input_1_shape[0]
-            return {'nElements': max(num_elements_in_input_0, num_elements_in_input_1)}
-        return {'nElements': num_elements_in_input_0}
-    if layer.op == TFMul.__name__:
-        if len(inputs)==2:
-            input_1 = inputs[1]
-            input_1_shape = get_effective_shape(input_1.shape)
-            if len(input_1_shape) == 0:
-                num_elements_in_input_1 = 1
-            # Else, the number of elements in the input tensor is the first dimension
-            # E.g. input_0.shape = (1, 2, 1), input_0_shape=(2, 1), num_elements_in_input_0=2
-            else:
-                num_elements_in_input_1 = input_1_shape[0]
-            return {'nElements': max(num_elements_in_input_0, num_elements_in_input_1)}
-        return {'nElements': num_elements_in_input_0}
-    if layer.op == TFDiv.__name__:
-        if len(inputs)==2:
-            input_1 = inputs[1]
-            input_1_shape = get_effective_shape(input_1.shape)
-            if len(input_1_shape) == 0:
-                num_elements_in_input_1 = 1
-            # Else, the number of elements in the input tensor is the first dimension
-            # E.g. input_0.shape = (1, 2, 1), input_0_shape=(2, 1), num_elements_in_input_0=2
-            else:
-                num_elements_in_input_1 = input_1_shape[0]
-            return {'nElements': max(num_elements_in_input_0, num_elements_in_input_1)}
-        return {'nElements': num_elements_in_input_0}
-    if layer.op == TFLog.__name__:
+    def is_in_ops(op_name: str, op_classes: list[object]) -> bool:
+        return op_name in map(lambda x: x.__name__, op_classes)
+
+    if is_in_ops(layer.op, [TFLog]):
         return {'e': 2, 'nInputs': num_elements_in_input_0}
+    if is_in_ops(layer.op, [TFReduceSum, TFReduceMean]):
+        return {'nInputs': num_elements_in_input_0}
+    if is_in_ops(layer.op, [TFAdd, TFSub, TFMul, TFDiv]):
+        if len(inputs)==2:
+            input_1 = inputs[1]
+            input_1_shape = get_effective_shape(input_1.shape)
+            if len(input_1_shape) == 0:
+                num_elements_in_input_1 = 1
+            # Else, the number of elements in the input tensor is the first dimension
+            # E.g. input_0.shape = (1, 2, 1), input_0_shape=(2, 1), num_elements_in_input_0=2
+            else:
+                num_elements_in_input_1 = input_1_shape[0]
+            return {'nElements': max(num_elements_in_input_0, num_elements_in_input_1)}
+        return {'nElements': num_elements_in_input_0}
     return {}
 
 
-def transpile(filename: str, output_dir: str = 'output', raw: bool = False, dec: int = 18) -> None:
+def transpile(templates: dict[str, Template], filename: str, output_dir: str = 'output', raw: bool = False, dec: int = 0) -> None:
     '''
     Traverse a keras model and convert it to a circom circuit.
 
@@ -192,8 +156,7 @@ def transpile(filename: str, output_dir: str = 'output', raw: bool = False, dec:
 
         # Add constraints for component inputs
         #   E.g. comp.in[0] <== prev_comp.out[0], ...
-
-        for input_index, _input in enumerate(layer.full_inputs):
+        for input_index, _input in enumerate(layer.inputs):
             # Handle left hand side
             component_input_name = f"{component_template.input_names[input_index]}"
             # How many `[]`s. E.g. (3, 4) -> dim=2
@@ -201,54 +164,37 @@ def transpile(filename: str, output_dir: str = 'output', raw: bool = False, dec:
             lhs_dim = component_template.input_dims[input_index]
 
             # Handle right hand side when it's keras tensor
-            if isinstance(_input, dict) and (_input['class_name']=='__keras_tensor__'):
-                input_name = _input['name']
-                input_shape = tuple(_input['config']['shape'])
-                if model.is_model_input(input_name) is True:
-                    # If this input is from `input_layer`, use the original tensor name for it
-                    from_component_name = None
-                    from_component_signal_name = input_name
-                    rhs_dim = len(model_input_name_to_shape[input_name])
-                else:
-                # Get the output name in the corresponding component
-                    from_component_layer = model.get_component_from_output_name(input_name)
-                    if from_component_layer is None:
-                        raise ValueError(f"Output {input_name} not found in any component")
-                    from_component_name = from_component_layer.name
-                    # get the index of the output tensor in the component
-                    from_component_output_tensor_names = [output.name for output in from_component_layer.outputs]
-                    from_component_output_index = from_component_output_tensor_names.index(input_name)
-                    # Sanity check
-                    if from_component_output_index == -1:
-                        raise ValueError(f"Output {input_name} not found in from_component {from_component_name}")
-
-                    # Use the index to get the component output name from template
-                    from_component_template = templates[from_component_layer.op]
-                    from_component_signal_name = from_component_template.output_names[from_component_output_index]
-                    rhs_dim = from_component_template.output_dims[from_component_output_index]
-                
-                # for handling with result in scalar like result of torch.mean()
-                if input_shape==():
-                    if len(layer.inputs)==2 and len(layer.inputs[1-input_index].shape)>=2:
-                        input_shape = (layer.inputs[1-input_index]).shape[:-1]
-                    else:
-                        input_shape =(1,1)
-
-            else:
-                # this is for actual constant
+            input_name = _input.name
+            input_shape = _input.shape
+            if _input.is_constant:
+                # If this input is a constant, use the value of the constant directly as the right hand side
                 from_component_name = None
-                if input_index ==0:
-                    from_component_signal_name = int(layer.config['first_operand'])
-                elif input_index ==1:
-                    from_component_signal_name = int(layer.config['second_operand'])
-                # rhs_dim = len(model_input_name_to_shape[_input.name])
-                # print('indexx: ', input_index)
+                # Scale the float value by 10^dec
+                scaled = int(_input.value * 10 ** dec)
+                from_component_signal_name = str(scaled)
                 rhs_dim = 0
-                if len(layer.inputs)>0 and len(layer.inputs[0].shape)>=2:
-                    input_shape = (layer.inputs[0]).shape[:-1]
-                    # print('hellloooo input shape ', input_shape)
-                else:
-                    input_shape =(1,1)
+            elif model.is_model_input(input_name) is True:
+                # If this input is from `input_layer`, use the original tensor name for it
+                from_component_name = None
+                from_component_signal_name = input_name
+                rhs_dim = len(model_input_name_to_shape[input_name])
+            else:
+            # Get the output name in the corresponding component
+                from_component_layer = model.get_component_from_output_name(input_name)
+                if from_component_layer is None:
+                    raise ValueError(f"Output {input_name} not found in any component")
+                from_component_name = from_component_layer.name
+                # get the index of the output tensor in the component
+                from_component_output_tensor_names = [output.name for output in from_component_layer.outputs]
+                from_component_output_index = from_component_output_tensor_names.index(input_name)
+                # Sanity check
+                if from_component_output_index == -1:
+                    raise ValueError(f"Output {input_name} not found in from_component {from_component_name}")
+
+                # Use the index to get the component output name from template
+                from_component_template = templates[from_component_layer.op]
+                from_component_signal_name = from_component_template.output_names[from_component_output_index]
+                rhs_dim = from_component_template.output_dims[from_component_output_index]
 
             # either "{component_name}." if input is from a component or "" if input is from model input
             from_component_prefix = f"{from_component_name}." if from_component_name is not None else ""

--- a/zkstats/onnx2circom/keras2circom/main.py
+++ b/zkstats/onnx2circom/keras2circom/main.py
@@ -18,8 +18,8 @@ from keras2circom import circom, transpiler
 def main():
     """ Main entry point of the app """
     args = docopt(__doc__)
-    circom.dir_parse('node_modules/circomlib-ml/circuits/', skips=['util.circom', 'circomlib-matrix', 'circomlib', 'crypto'])
-    transpiler.transpile(args['<model.h5>'], args['--output'], args['--raw'], args['--decimals'])
+    templates = circom.dir_parse('node_modules/circomlib-ml/circuits/', skips=['util.circom', 'circomlib-matrix', 'circomlib', 'crypto'])
+    transpiler.transpile(templates, args['<model.h5>'], args['--output'], args['--raw'], args['--decimals'])
 
 if __name__ == "__main__":
     """ This is executed when run from the command line """

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -65,10 +65,7 @@ template TFReduceMean(nInputs) {
         sum.in[i] <== in[i];
     }
 
-    component div = TFDiv();
-    div.left <== sum.out;
-    div.right <== nInputs;
-    out <== div.out;
+    out <== sum.out / nInputs;
 }
 
 
@@ -95,7 +92,7 @@ template TFLog(e, nInputs) {
     signal x[nInputs];
     signal e_until[nInputs][max_exponent];
     signal sel[nInputs][max_exponent];
-    component sel_comp[nInputs][max_exponent];
+    // component sel_comp[nInputs][max_exponent];
     component k_by_sum[nInputs];
     signal k[nInputs];
     component b_by_sum[nInputs];
@@ -122,10 +119,7 @@ template TFLog(e, nInputs) {
         sel[input_index][0] <== x[input_index] <= 1;
 
         for (var i = 1; i < max_exponent; i++) {
-            sel_comp[input_index][i] = TFMul();
-            sel_comp[input_index][i].left <== x[input_index] > e_until[input_index][i-1];
-            sel_comp[input_index][i].right <== x[input_index] <= e_until[input_index][i];
-            sel[input_index][i] <== sel_comp[input_index][i].out;
+            sel[input_index][i] <== x[input_index] > e_until[input_index][i-1] * x[input_index] <= e_until[input_index][i];
         }
         k_by_sum[input_index] = TFReduceSum(max_exponent);
         for (var i = 0; i < max_exponent; i++) {

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -1,37 +1,42 @@
 pragma circom 2.0.0;
 
 
-template TFAdd() {
-    signal input left;
-    signal input right;
-    signal output out;
-
-    out <== left + right;
+template TFAdd(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i< nElements; i ++){
+        out[i] <== left[i] + right[i];
+    }
 }
 
-template TFSub() {
-    signal input left;
-    signal input right;
-    signal output out;
-
-    out <== left - right;
+template TFSub(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i< nElements; i++){
+        out[i] <== left[i] - right[i];
+    }
 }
 
-template TFMul() {
-    signal input left;
-    signal input right;
-    signal output out;
-
-    out <== left * right;
+template TFMul(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i] * right[i];
+    }
 }
 
-template TFDiv() {
-    signal input left;
-    signal input right;
-    signal output out;
-
-    out <== left / right;
+template TFDiv(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i] / right[i];
+    }
 }
+
 
 template TFReduceSum(nInputs) {
     signal input in[nInputs];
@@ -41,10 +46,10 @@ template TFReduceSum(nInputs) {
     sum_till[0] <== in[0];
     component add[nInputs-1];
     for (var i = 0; i<nInputs-1; i++){
-        add[i] = TFAdd();
-        add[i].left <== sum_till[i];
-        add[i].right <== in[i+1];
-        sum_till[i+1] <== add[i].out;
+        add[i] = TFAdd(1);
+        add[i].left[0] <== sum_till[i];
+        add[i].right[0] <== in[i+1];
+        sum_till[i+1] <== add[i].out[0];
     }
     // FIXME: adding 0 is a workaround for nInputs=1, to force `in[0][0]` to be an
     // input in a gate
@@ -68,9 +73,9 @@ template TFReduceMean(nInputs) {
 
 
 // TODO: e should be 2.71828 instead of 2 for now
-template TFLog(e) {
-    signal input in;
-    signal output out;
+template TFLog(e, nInputs) {
+    signal input in[nInputs];
+    signal output out[nInputs];
 
     // Approximate natural log with talyer series. For 0 < x <= 2
     // - ln(x) = ln(1 + (x-1)) = 0 + (x-1) - (x-1)^2/2 + (x-1)^3/3 - (x-1)^4/4 + ...
@@ -87,61 +92,74 @@ template TFLog(e) {
     // Step 1: Find b so that b = e^k and x/b <= 1
     // find b so that x/b < 1 and can be used in talyer series
     // b = e^k, e=2.71828
-    signal x <== in;
-    // e_until[i] = e^i
-    signal e_until[max_exponent];
-    e_until[0] <== 1;
-    for (var i = 1; i < max_exponent; i++) {
-        e_until[i] <== e_until[i-1] * e;
-    }
+    signal x[nInputs];
+    signal e_until[nInputs][max_exponent];
+    signal sel[nInputs][max_exponent];
+    component sel_comp[nInputs][max_exponent];
+    component k_by_sum[nInputs];
+    signal k[nInputs];
+    component b_by_sum[nInputs];
+    signal b[nInputs];
+    signal x_over_b[nInputs];
+    signal x_over_b_minus_one_exp[nInputs][taylor_series_iterations];
+    signal taylor_series[nInputs][taylor_series_iterations];
+    signal taylor_series_sum[nInputs];
+    component taylor_series_sum_comp[nInputs];
 
-    // e^k >= x and e^(k-1) < x
-    // sel : [0, 0, 1, 0, 0]
-    // k   : [0, 1, 2, 3, 4]
-    // sum(sel*k) = k
-    signal sel[max_exponent];
-    sel[0] <== x <= 1;
-    component sel_comp[max_exponent];
-    for (var i = 1; i < max_exponent; i++) {
-        sel_comp[i] = TFMul();
-        sel_comp[i].left <== x > e_until[i-1];
-        sel_comp[i].right <== x <= e_until[i];
-        sel[i] <== sel_comp[i].out;
-    }
-    component k_by_sum = TFReduceSum(max_exponent);
-    for (var i = 0; i < max_exponent; i++) {
-        k_by_sum.in[i] <== sel[i] * i;
-    }
-    signal k <== k_by_sum.out;
-    // sum(sel*e^k) = b
-    component b_by_sum = TFReduceSum(max_exponent);
-    for (var i = 0; i < max_exponent; i++) {
-        b_by_sum.in[i] <== sel[i] * e_until[i];
-    }
-    signal b <== b_by_sum.out;
+    for (var input_index = 0; input_index < nInputs; input_index++){
+        x[input_index] <== in[input_index];
+        // e_until[i] = e^i
+        e_until[input_index][0] <== 1;
+        for (var i = 1; i < max_exponent; i++) {
+            e_until[input_index][i] <== e_until[input_index][i-1] * e;
+        }
 
-    // Step 2: Calculate ln(x/b) using talyer series
-    signal x_over_b <== x / b;
+        // e^k >= x and e^(k-1) < x
+        // sel : [0, 0, 1, 0, 0]
+        // k   : [0, 1, 2, 3, 4]
+        // sum(sel*k) = k
 
-    signal x_over_b_minus_one_exp[taylor_series_iterations];
-    x_over_b_minus_one_exp[0] <== 0;
-    x_over_b_minus_one_exp[1] <== (x / b) - 1;
-    for (var i = 2; i < taylor_series_iterations; i++) {
-        x_over_b_minus_one_exp[i] <== x_over_b_minus_one_exp[i-1] * (1 - x_over_b);
+        sel[input_index][0] <== x[input_index] <= 1;
+
+        for (var i = 1; i < max_exponent; i++) {
+            sel_comp[input_index][i] = TFMul();
+            sel_comp[input_index][i].left <== x[input_index] > e_until[input_index][i-1];
+            sel_comp[input_index][i].right <== x[input_index] <= e_until[input_index][i];
+            sel[input_index][i] <== sel_comp[input_index][i].out;
+        }
+        k_by_sum[input_index] = TFReduceSum(max_exponent);
+        for (var i = 0; i < max_exponent; i++) {
+            k_by_sum[input_index].in[i] <== sel[input_index][i] * i;
+        }
+        k[input_index] <== k_by_sum[input_index].out;
+        // sum(sel*e^k) = b
+        b_by_sum[input_index] = TFReduceSum(max_exponent);
+        for (var i = 0; i < max_exponent; i++) {
+            b_by_sum[input_index].in[i] <== sel[input_index][i] * e_until[input_index][i];
+        }
+        b[input_index] <== b_by_sum[input_index].out;
+
+        // Step 2: Calculate ln(x/b) using talyer series
+        x_over_b[input_index] <== x[input_index] / b[input_index];
+
+
+        x_over_b_minus_one_exp[input_index][0] <== 0;
+        x_over_b_minus_one_exp[input_index][1] <== (x[input_index] / b[input_index]) - 1;
+        for (var i = 2; i < taylor_series_iterations; i++) {
+            x_over_b_minus_one_exp[input_index][i] <== x_over_b_minus_one_exp[input_index][i-1] * (1 - x_over_b[input_index]);
+        }
+
+        taylor_series[input_index][0] <== 0;
+        for (var i = 1; i < taylor_series_iterations; i++) {
+            taylor_series[input_index][i] <== x_over_b_minus_one_exp[input_index][i] / i;
+        }
+
+        taylor_series_sum_comp[input_index] = TFReduceSum(taylor_series_iterations);
+        for (var i = 0; i < taylor_series_iterations; i++) {
+            taylor_series_sum_comp[input_index].in[i] <== taylor_series[input_index][i];
+        }
+        taylor_series_sum[input_index] <== taylor_series_sum_comp[input_index].out;
+
+        out[input_index] <== taylor_series_sum[input_index] + k[input_index];
     }
-
-    signal taylor_series[taylor_series_iterations];
-    taylor_series[0] <== 0;
-    for (var i = 1; i < taylor_series_iterations; i++) {
-        taylor_series[i] <== x_over_b_minus_one_exp[i] / i;
-    }
-
-    signal taylor_series_sum;
-    component taylor_series_sum_comp = TFReduceSum(taylor_series_iterations);
-    for (var i = 0; i < taylor_series_iterations; i++) {
-        taylor_series_sum_comp.in[i] <== taylor_series[i];
-    }
-    taylor_series_sum <== taylor_series_sum_comp.out;
-
-    out <== taylor_series_sum + k;
 }

--- a/zkstats/onnx2circom/onnx2keras/layers/mathematics_layers.py
+++ b/zkstats/onnx2circom/onnx2keras/layers/mathematics_layers.py
@@ -334,12 +334,24 @@ class TFExp(keras.layers.Layer):
 
 @OPERATOR.register_operator("Log")
 class TFLog(keras.layers.Layer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
         super().__init__()
+        self.tensor_grap = tensor_grap
+        self.node_weights = node_weights
+        self.node_inputs = node_inputs
+        self.node_attribute = node_attribute
 
     def call(self, inputs, *args, **kwargs):
         return keras.ops.log(inputs)
-
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "tensor_grap":self.tensor_grap,
+            'node_weights':self.node_weights,
+            'node_inputs':self.node_inputs,
+            'node_attribute':self.node_attribute,
+        })
+        return config
 @OPERATOR.register_operator("Floor")
 class TFFloor(keras.layers.Layer):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
First Draft, but functional of making 2-inputs function working correctly. 

In model.py
-Since layer.input doesn't cover constant number (which is not keras_tensor), we create variable called full_inputs in class Layer to encapsulate all inputs including these constant inputs. (If this makes sense, can make it become real self.inputs in the future)

In mathematics_layers.py
-Since we want to generalize full_inputs which require get_config(), we modify TFLog layer here to have get_config() function

In MPC circom
TFAdd, TFSub, TFDiv, TFMul  —> nElements
TFLog —> nInputs

In Transpiler.py
Take all those changes above and make it work with all these examples shown in test_two_inputs.py. Already pass all test cases below

Test cases
x+4
x+torch.log(x)
torch.mean(x)+4
torch.mean(x)+torch.sum(x)
torch.mean(x)+x
torch.mean(x)+torch.log(x)

Swap order first-second operand, then change operations to subtraction
