### PR TITLE
Parse outputs from mpspdz

### DIFF
--- a/tests/onnx2circom/test_mpspdz.py
+++ b/tests/onnx2circom/test_mpspdz.py
@@ -1,0 +1,69 @@
+import torch
+
+from zkstats.backends.mpspdz import mpspdz_output_to_tensors
+
+
+def test_mpspdz_output_to_tensors_success():
+    output_dict = {
+        "a[0][0][0]": 1,
+        "a[0][0][1]": 2,
+        "a[0][1][0]": 3,
+        "a[0][1][1]": 4,
+        "a[1][0][0]": 5,
+        "a[1][0][1]": 6,
+        "a[1][1][0]": 7,
+        "a[1][1][1]": 8,
+        "b[0][0]": 9,
+        "b[0][1]": 10,
+        "b[1][0]": 11,
+        "b[1][1]": 12,
+        "c[0]": 13,
+        "c[1]": 14,
+        "d": 15,
+    }
+    result = mpspdz_output_to_tensors(output_dict)
+
+    assert torch.equal(result["a"], torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]))
+    assert torch.equal(result["b"], torch.tensor([[9, 10], [11, 12]]))
+    assert torch.equal(result["c"], torch.tensor([13, 14]))
+    assert result["d"] == 15
+
+
+def test_mpspdz_output_to_tensors_missing_index_3d():
+    output_dict_missing = {
+        "a[0][0][0]": 1,
+        "a[0][0][1]": 2,
+        "a[0][1][0]": 3,
+        "a[0][1][1]": 4,
+        "a[1][0][0]": 5,
+        "a[1][0][1]": 6,
+        "a[1][1][0]": 7,
+        # Missing "a[1][1][1]"
+        "b[0][0][0]": 9,
+        "b[0][0][1]": 10,
+        "c": 11,
+    }
+    try:
+        result = mpspdz_output_to_tensors(output_dict_missing)
+    except ValueError as e:
+        assert str(e) == "Missing data for index (1, 1, 1) in dimension 1"
+    else:
+        assert False, "Expected ValueError for missing index"
+
+
+def test_mpspdz_output_to_tensors_missing_index_2d():
+    output_dict_missing = {
+        "a[0][0]": 1,
+        "a[0][1]": 2,
+        "a[1][0]": 3,
+        # Missing "a[1][1]"
+        "b[0][0]": 5,
+        "b[1][0]": 6,
+        "c": 7
+    }
+    try:
+        result = mpspdz_output_to_tensors(output_dict_missing)
+    except ValueError as e:
+        assert str(e) == "Missing data for index (1, 1) in dimension 1"
+    else:
+        assert False, "Expected ValueError for missing index"

--- a/tests/onnx2circom/test_mpspdz.py
+++ b/tests/onnx2circom/test_mpspdz.py
@@ -1,6 +1,6 @@
 import torch
 
-from zkstats.backends.mpspdz import mpspdz_output_to_tensors
+from zkstats.backends.mpspdz import mpspdz_output_to_tensors, tensors_to_circom_mpspdz_inputs
 
 
 def test_mpspdz_output_to_tensors_success():
@@ -67,3 +67,11 @@ def test_mpspdz_output_to_tensors_missing_index_2d():
         assert str(e) == "Missing data for index (1, 1) in dimension 1"
     else:
         assert False, "Expected ValueError for missing index"
+
+
+def test_tensor_inputs_to_circom():
+    input_names = ['keras_tensor_0', 'input_2']
+    input_tensors = [torch.tensor([[[1], [34]]]), torch.tensor(5)]
+
+    output = tensors_to_circom_mpspdz_inputs(input_names, input_tensors)
+    assert output == {'keras_tensor_0[0][0][0]': 1, 'keras_tensor_0[0][1][0]': 34, 'input_2': 5}

--- a/tests/onnx2circom/test_onnx_to_circom.py
+++ b/tests/onnx2circom/test_onnx_to_circom.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 
-from .utils import compile_and_check
+from .utils import compile_and_run_mpspdz, run_torch_model
 
 
 def test_onnx_to_circom(tmp_path):
@@ -16,4 +16,11 @@ def test_onnx_to_circom(tmp_path):
             l = torch.log(x)  # 5,3,3
             return m*s+l #773, 771, 771
 
-    compile_and_check(Model, data, tmp_path)
+    # Run the model directly with torch
+    output_torch = run_torch_model(Model, data)
+    # Compile and run the model with MP-SPDZ
+    outputs_mpspdz = compile_and_run_mpspdz(Model, data, tmp_path)
+    # The model only has one output tensor
+    assert len(outputs_mpspdz) == 1, f"Expecting only one output tensor, but got {len(outputs_mpspdz)} tensors."
+    # Compare the output tensor with the expected output. Should be close
+    assert torch.allclose(outputs_mpspdz[0], output_torch, rtol=1e-3), f"Output tensor is not close to the expected output tensor. {outputs_mpspdz[0]=}, {output_torch=}"

--- a/tests/onnx2circom/test_onnx_to_keras.py
+++ b/tests/onnx2circom/test_onnx_to_keras.py
@@ -41,7 +41,7 @@ class LogModel(nn.Module):
     [
         (SumModel, torch.tensor(100.0)),
         (MeanModel, torch.tensor(33.333)),
-        (LogModel, torch.tensor([2.3026, 3.6889, 3.9120]).reshape(1, -1, 1)),
+        (LogModel, torch.tensor([2.3026, 3.6889, 3.9120])),
     ]
 )
 def test_onnx_to_keras(tmp_path, model_type: Type[nn.Module], expected_res: float):
@@ -81,5 +81,5 @@ def run_keras_model(keras_path: Path, data: torch.Tensor) -> torch.Tensor:
     # result is numpy.float32
     output_keras = model.predict(data)
     # Transform it to torch.Tensor to make it align with torch output
-    return torch.tensor(output_keras, dtype = torch.float32)
+    return torch.tensor(output_keras, dtype = torch.float32).reshape(-1)
 

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -42,8 +42,8 @@ def test_two_inputs(func, tmp_path):
     outputs_mpspdz = compile_and_run_mpspdz(Model, data, tmp_path)
     # The model only has one output tensor
     assert len(outputs_mpspdz) == 1, f"Expecting only one output tensor, but got {len(outputs_mpspdz)} tensors."
-    # Compare the output tensor with the expected output. Should be close
-    assert torch.allclose(outputs_mpspdz[0], output_torch, rtol=1e-3), f"Output tensor is not close to the expected output tensor. {outputs_mpspdz[0]=}, {output_torch=}"
+    # Compare the output tensor with the expected output. Different should be within 0.001
+    assert torch.allclose(outputs_mpspdz[0], output_torch, rtol=0.001), f"Output tensor is not close to the expected output tensor. {outputs_mpspdz[0]=}, {output_torch=}"
 
 
 def log(x, base=None):

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 import pytest
 
-from .utils import compile_and_check
+from .utils import compile_and_check, compile_and_run_mpspdz, run_torch_model
 
 
 @pytest.mark.parametrize(
@@ -23,14 +23,6 @@ from .utils import compile_and_check
         pytest.param(lambda x: x + torch.mean(x), id="x + mean(x)"),
         pytest.param(lambda x: torch.mean(x) - x, id="mean(x) - x"),
         pytest.param(lambda x: x - torch.mean(x), id="x - mean(x)"),
-        # `log` is slower. We can test non-slow ones with `pytest -m "not slow"`
-        pytest.param(lambda x: x + torch.log(x), id="x + log(x)"),
-        pytest.param(lambda x: torch.log(x) + x, id="log(x) + x"),
-        pytest.param(lambda x: x - torch.log(x), id="x - log(x)"),
-        pytest.param(lambda x: torch.log(x) - x, id="log(x) - x"),
-        pytest.param(lambda x: torch.mean(x) + torch.log(x), id="mean(x) + log(x)"),
-        pytest.param(lambda x: torch.log(x) + torch.mean(x), id="log(x) + mean(x)"),
-        pytest.param(lambda x: torch.mean(x) - torch.log(x), id="mean(x) - log(x)"),
     ]
 )
 def test_two_inputs(func, tmp_path):
@@ -40,6 +32,57 @@ def test_two_inputs(func, tmp_path):
     ).reshape(1, -1, 1)
     class Model(nn.Module):
         def forward(self, x):
+            # x+log(x) = 32+log(32), 8+log(8), 8+log(8)
+            #          =
             return func(x)
 
     compile_and_check(Model, data, tmp_path)
+
+
+def log(x, base=None):
+    # if base is None, we use natural logarithm
+    if base is None:
+        return torch.log(x)
+    # else, convert to `base` by `log_base(x) = log_k(x) / log_k(base)`
+    return torch.log(x) / torch.log(torch.tensor(float(base)))
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(lambda x, base: x + log(x, base), id="x + log(x)"),
+        pytest.param(lambda x, base: log(x, base) + x, id="log(x) + x"),
+        pytest.param(lambda x, base: x - log(x, base), id="x - log(x)"),
+        pytest.param(lambda x, base: log(x, base) - x, id="log(x) - x"),
+        pytest.param(lambda x, base: torch.mean(x) + log(x, base), id="mean(x) + log(x)"),
+        pytest.param(lambda x, base: log(x, base) + torch.mean(x), id="log(x) + mean(x)"),
+        pytest.param(lambda x, base: torch.mean(x) - log(x, base), id="mean(x) - log(x)"),
+    ]
+)
+def test_two_inputs_with_logs(func, tmp_path):
+    e = 2.7183
+    data = torch.tensor(
+        [32, 8, 8],
+        dtype = torch.float32,
+    ).reshape(1, -1, 1)
+    class ModelMPSPDZ(nn.Module):
+        def forward(self, x):
+            # FIXME: We should remove `log` and use `torch.log` directly when
+            # we support base=e.
+            # Now we need to convert base to `e` since we currently use `base=2` in mp-spdz
+            # to calculate ln(x) = log_2(x) / log_2(e)
+            return func(x, base=e)
+
+    output_tensor_mpsdpz = compile_and_run_mpspdz(ModelMPSPDZ, data, tmp_path)
+
+    class ModelTorch(nn.Module):
+        def forward(self, x):
+            # base = None means we don't need the conversion at all since torch uses e by default
+            return func(x, base=None)
+
+    output_torch = run_torch_model(ModelTorch, data)
+    assert output_tensor_mpsdpz.shape == output_torch.shape, f"Output tensor shape is not the same. {output_tensor_mpsdpz.shape=}, {output_torch.shape=}"
+    # Compare the output tensor with the expected output.
+    # Difference should be within 20% (|output_tensor_mpsdpz-output_torch|/|output_torch| <= error_rate)
+    error_rate = 0.2
+    assert torch.allclose(output_tensor_mpsdpz, output_torch, rtol=error_rate), f"Output tensor is not close to the expected output tensor. {output_tensor_mpsdpz=}, {output_torch=}"

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -131,8 +131,14 @@ def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path:
         )
         print(f"Party {party} input path: {mpspdz_input_path}")
     print(f"Running mp-spdz circuit {mpspdz_circuit_path}...")
-    # TODO: parse output from MP-SPDZ and compare with torch output
-    run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
+    # E.g. mpspdz_output = {'keras_tensor_3': tensor()}
+    output_name_to_tensor = run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
+    # we should only have one output tensor
+    assert len(output_name_to_tensor) == 1
+    # TODO: we should access the output tensor by name. It can be retrieved from keras model.
+    output_tensor_mpsdpz = next(iter(output_name_to_tensor.values()))
+    # Compare the output tensor with the expected output. Should be close
+    assert torch.allclose(output_tensor_mpsdpz, output_torch, atol=1e-3), f"Output tensor is not close to the expected output tensor. {output_tensor=}, {output_torch=}"
 
 
 def run_torch_model(model_type: Type[nn.Module], data: torch.Tensor) -> torch.Tensor:

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -9,11 +9,11 @@ import os
 
 from zkstats.onnx2circom import onnx_to_circom
 from zkstats.arithc_to_bristol import parse_arithc_json
-from zkstats.backends.mpspdz import generate_mpspdz_circuit, generate_mpspdz_inputs_for_party, run_mpspdz_circuit
+from zkstats.backends.mpspdz import generate_mpspdz_circuit, generate_mpspdz_inputs_for_party, run_mpspdz_circuit, tensors_to_circom_mpspdz_inputs
 
 
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/mhchia/projects/work/pse/circom-2-arithc')
-MP_SPDZ_PROJECT_ROOT = Path('/Users/mhchia/projects/work/pse/MP-SPDZ')
+CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
+MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
 
 
 
@@ -36,7 +36,7 @@ def compile_and_run_mpspdz(model_type: Type[nn.Module], data: torch.Tensor, tmp_
     torch_model_to_onnx(model_type, data, onnx_path)
     assert onnx_path.exists() is True, f"The output file {onnx_path} does not exist."
     print("Transforming onnx model to circom...")
-    output_names_circom = onnx_to_circom(onnx_path, circom_path)
+    circom_input_names, circom_output_names = onnx_to_circom(onnx_path, circom_path)
     assert circom_path.exists() is True, f"The output file {circom_path} does not exist."
 
     arithc_path = output_path / f"{model_name}.json"
@@ -68,9 +68,12 @@ def compile_and_run_mpspdz(model_type: Type[nn.Module], data: torch.Tensor, tmp_
     print("!@# input_names=", input_names)
 
     num_parties = 2
-    # TODO: This should come from users. Here we just set up a config json
-    # for convenience (which input is from which party). Now just put every input to party 0.
-    # Assume the input data is a 1-d tensor
+    # TODO: Now we assume all inputs are from party 0 for convenience.
+    # If we want to support inputs from both parties, we need to change the code here.
+    # We also need config file for mpcstats library to specify which tensor is from which party,
+    # and translate these information to the mpc_settings.json
+
+    # Prepare the mpc_settings.json
     mpc_settings_path = output_path / f"{model_name}.mpc_settings.json"
     mpc_settings_path.parent.mkdir(parents=True, exist_ok=True)
     # party 0 is alice, having input a, and output a_add_b, a_mul_c are revealed to
@@ -104,13 +107,21 @@ def compile_and_run_mpspdz(model_type: Type[nn.Module], data: torch.Tensor, tmp_
     print("!@# mpc_settings_path=", mpc_settings_path)
 
     # Prepare data for party 0
-    data_list = data.reshape(-1)
+    # TODO: Should be changed if we want to support inputs from different parties
+    tensor_list = [data]
     input_paths = [output_path / f"{model_name}_party_{i}.inputs.json" for i in range(num_parties)]
     input_paths[0].parent.mkdir(parents=True, exist_ok=True)
+    # preprocess tensors from (1, N, 1) to (N, 1)
+    tensor_list_squeezed = [tensor.squeeze(0) for tensor in tensor_list]
+    circom_inputs = tensors_to_circom_mpspdz_inputs(circom_input_names, tensor_list_squeezed)
+    # postprocess tensor values from floats to integers
+    # TODO: if we want to support float inputs, we need to change the code here
+    circom_int_inputs = {
+        k: int(v)
+        for k, v in circom_inputs.items()
+    }
     with open(input_paths[0], 'w') as f:
-        json.dump({
-            name: int(x) for name, x in zip(input_names, data_list.tolist())
-        }, f, indent=4)
+        json.dump(circom_int_inputs, f, indent=4)
     # input 1 is empty
     with open(input_paths[1], 'w') as f:
         json.dump({}, f)
@@ -128,10 +139,10 @@ def compile_and_run_mpspdz(model_type: Type[nn.Module], data: torch.Tensor, tmp_
         )
         print(f"Party {party} input path: {mpspdz_input_path}")
     print(f"Running mp-spdz circuit {mpspdz_circuit_path}...")
-    # E.g. mpspdz_output = {'keras_tensor_3': tensor(), '
+    # E.g. mpspdz_output = {'keras_tensor_3': tensor([[[2]]]), 'output_2': tensor(1)}
     output_name_to_tensor = run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
-    # we should only have one output tensor
-    output_tensor_list = [output_name_to_tensor[name] for name in output_names_circom]
+    # Return the tensors in the order they passed to torch, and reshape them from (1, N, 1) back to (N,)
+    output_tensor_list = [output_name_to_tensor[name].reshape(-1) for name in circom_output_names]
     return output_tensor_list
 
 

--- a/zkstats/backends/mpspdz.py
+++ b/zkstats/backends/mpspdz.py
@@ -383,7 +383,7 @@ def tensors_to_circom_mpspdz_inputs(input_names: list[str], input_tensors: list[
     Flatten the input tensors and return a dictionary of the flattened tensors.
 
     E.g. input_names = ['keras_tensor_0', 'input_2'], input_tensors = [torch.tensor([[[1], [34]]]), torch.tensor(5)]
-    Output: {'keras_tensor_0[0][0]': 1, 'keras_tensor_0[1][0]': 34, 'input_2': 5}
+    Output: {'keras_tensor_0[0][0][0]': 1, 'keras_tensor_0[0][1][0]': 34, 'input_2': 5}
     """
     output_dict = {}
 

--- a/zkstats/onnx2circom/__init__.py
+++ b/zkstats/onnx2circom/__init__.py
@@ -26,7 +26,7 @@ def onnx_to_keras(onnx_path: Path, generated_keras_path: Path):
     )
 
 
-def keras_to_circom(keras_path: Path, generated_circom_path: Path):
+def keras_to_circom(keras_path: Path, generated_circom_path: Path) -> list[str]:
     # Ref: https://github.com/JernKunpittaya/keras2circom/blob/42dc97e4ce0543dde68b37e9b220a29bf88be84d/main.py#L21
     # circom.dir_parse(
     #     MPC_CIRCOM_PATH,
@@ -37,7 +37,7 @@ def keras_to_circom(keras_path: Path, generated_circom_path: Path):
     # transpiler.transpile(args['<model.h5>'], args['--output'], args['--raw'], args['--decimals'])
     # keras2circom_output_dir = Path(tempfile.mkdtemp())
     keras2circom_output_dir = generated_circom_path.parent
-    transpiler.transpile(
+    circom_output_names = transpiler.transpile(
         templates,
         str(keras_path),
         str(keras2circom_output_dir),
@@ -46,13 +46,14 @@ def keras_to_circom(keras_path: Path, generated_circom_path: Path):
     # Copy the generated circom file to the target path
     generated_circom_path.parent.mkdir(parents=True, exist_ok=True)
     generated_circom_path.write_text(generated_circom_original.read_text())
+    return circom_output_names
 
 
-def onnx_to_circom(onnx_path_str: Union[str, Path], generated_circom_path_str: Union[str, Path]):
+def onnx_to_circom(onnx_path_str: Union[str, Path], generated_circom_path_str: Union[str, Path]) -> list[str]:
     onnx_path = Path(onnx_path_str)
     generated_circom_path = Path(generated_circom_path_str)
     keras_path = onnx_path.parent / f"{onnx_path.stem}.keras"
     print("Transforming onnx model to keras...")
     onnx_to_keras(onnx_path, keras_path)
     print("Transforming keras model to circom...")
-    keras_to_circom(keras_path, generated_circom_path)
+    return keras_to_circom(keras_path, generated_circom_path)

--- a/zkstats/onnx2circom/__init__.py
+++ b/zkstats/onnx2circom/__init__.py
@@ -26,7 +26,7 @@ def onnx_to_keras(onnx_path: Path, generated_keras_path: Path):
     )
 
 
-def keras_to_circom(keras_path: Path, generated_circom_path: Path) -> list[str]:
+def keras_to_circom(keras_path: Path, generated_circom_path: Path) -> tuple[list[str], list[str]]:
     # Ref: https://github.com/JernKunpittaya/keras2circom/blob/42dc97e4ce0543dde68b37e9b220a29bf88be84d/main.py#L21
     # circom.dir_parse(
     #     MPC_CIRCOM_PATH,
@@ -37,7 +37,7 @@ def keras_to_circom(keras_path: Path, generated_circom_path: Path) -> list[str]:
     # transpiler.transpile(args['<model.h5>'], args['--output'], args['--raw'], args['--decimals'])
     # keras2circom_output_dir = Path(tempfile.mkdtemp())
     keras2circom_output_dir = generated_circom_path.parent
-    circom_output_names = transpiler.transpile(
+    circom_input_names, circom_output_names = transpiler.transpile(
         templates,
         str(keras_path),
         str(keras2circom_output_dir),
@@ -46,10 +46,10 @@ def keras_to_circom(keras_path: Path, generated_circom_path: Path) -> list[str]:
     # Copy the generated circom file to the target path
     generated_circom_path.parent.mkdir(parents=True, exist_ok=True)
     generated_circom_path.write_text(generated_circom_original.read_text())
-    return circom_output_names
+    return circom_input_names, circom_output_names
 
 
-def onnx_to_circom(onnx_path_str: Union[str, Path], generated_circom_path_str: Union[str, Path]) -> list[str]:
+def onnx_to_circom(onnx_path_str: Union[str, Path], generated_circom_path_str: Union[str, Path]) -> tuple[list[str], list[str]]:
     onnx_path = Path(onnx_path_str)
     generated_circom_path = Path(generated_circom_path_str)
     keras_path = onnx_path.parent / f"{onnx_path.stem}.keras"

--- a/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
@@ -117,6 +117,8 @@ def transpile(templates: dict[str, Template], filename: str, output_dir: str = '
         model_output.name: get_effective_shape(model_output.shape)
         for model_output in model.model_outputs
     }
+    circom_output_names = [output.name for output in model.model_outputs]
+
     # Declare signals for model inputs and outputs
     # E.g. signal input input_layer[2];
     input_signal_declarations = [
@@ -264,6 +266,8 @@ component main = Model();
     with open(output_dir + '/circuit.circom', 'w') as f:
         f.write(circom_result)
 
+    return circom_output_names
+
 
 def parse_args(template_args: typing.List[str], args: typing.Dict[str, typing.Any]) -> str:
     if len(template_args) != len(args):
@@ -274,10 +278,7 @@ def parse_args(template_args: typing.List[str], args: typing.Dict[str, typing.An
     return args_str.format(**args)
 
 
-# def get_effective_shape(shape: tuple[int, ...]) -> tuple:
-#     # remove the first dimension. E.g. (1, 2, 1) -> (2, 1)
-#     return shape[1:]
-def get_effective_shape(shape: tuple[int, ...]) -> tuple:
+def get_effective_shape(shape: tuple[int, ...]) -> tuple[int, ...]:
     # remove the first dimension. E.g. (1, 2, 1) -> (2, 1)
     return shape[1:]
 

--- a/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
@@ -95,7 +95,7 @@ def get_component_args_values(layer: Layer) -> typing.Dict[str, typing.Any]:
     return {}
 
 
-def transpile(templates: dict[str, Template], filename: str, output_dir: str = 'output', raw: bool = False, dec: int = 0) -> None:
+def transpile(templates: dict[str, Template], filename: str, output_dir: str = 'output', raw: bool = False, dec: int = 0) -> tuple[list[str], list[str]]:
     '''
     Traverse a keras model and convert it to a circom circuit.
 
@@ -117,6 +117,7 @@ def transpile(templates: dict[str, Template], filename: str, output_dir: str = '
         model_output.name: get_effective_shape(model_output.shape)
         for model_output in model.model_outputs
     }
+    circom_input_names = [input.name for input in model.model_inputs]
     circom_output_names = [output.name for output in model.model_outputs]
 
     # Declare signals for model inputs and outputs
@@ -266,7 +267,7 @@ component main = Model();
     with open(output_dir + '/circuit.circom', 'w') as f:
         f.write(circom_result)
 
-    return circom_output_names
+    return circom_input_names, circom_output_names
 
 
 def parse_args(template_args: typing.List[str], args: typing.Dict[str, typing.Any]) -> str:


### PR DESCRIPTION
## What's done?
- Parsed output from mpspdz to tensor
- Compared output with the one returned from torch model
- Translated inputs from torch tensors to circom in the correct order

## To-Do
- [x] Should get the result tensor with its name (keras_tensor_x). Now we just assume there is only one tensor and always return the first one
- [x] Only tested with tests/onnx2circom/test_onnx_to_circom.py. Should also fix some failures in tests/onnx2circom/test_two_inputs.py
