### PR TITLE
Resolve keras_tensor case while loop + enable circom of bool-related functions

### DIFF
--- a/tests/onnx2circom/README.md
+++ b/tests/onnx2circom/README.md
@@ -53,7 +53,7 @@ ls semi-party.x
 
 ### Run the test
 
-Modify the configs in `tests/onnx2circom/test_onnx_to_circom.py` to point to the correct paths. Just fill in the paths to the two projects you just cloned.
+Modify the configs in `tests/onnx2circom/utils.py` to point to the correct paths. Just fill in the paths to the two projects you just cloned.
 
 ```bash
 # NOTE: Change the path to your own path

--- a/tests/onnx2circom/test_comp.py
+++ b/tests/onnx2circom/test_comp.py
@@ -1,24 +1,27 @@
 import torch
 import torch.nn as nn
 
-from .utils import compile_and_check, compile_and_check_mult
+from .utils import compile_and_check
 
 # two tensor stuffs
-def test_onnx_to_circom(tmp_path):
+def test_comparison(tmp_path):
     data_1 = torch.tensor(
         [32, 8, 8],
         dtype = torch.float32,
     ).reshape(1, -1, 1)
     data_2 = torch.tensor(
-        [3, 3, 5],
+        [3, 8, 9],
         dtype = torch.float32,
     ).reshape(1, -1, 1)
     class Model(nn.Module):
         def forward(self, x, y):
-            return x+y
-            m = torch.mean(x)  # 16
-            s = torch.sum(x)  # 48
-            l = torch.log(x)  # 5,3,3
-            return m*s+l #773, 771, 771
+            return torch.logical_or(x<=y, x<y)
+            return torch.logical_and(x<=y, x<y)
+            return torch.logical_not(x<=y)
+            return x>y
+            return x>=y
+            return x<y
+            return x<=y
+            return x==y
 
-    compile_and_check_mult(Model, (data_1,data_2), tmp_path)
+    compile_and_check(Model, (data_1, data_2), tmp_path)

--- a/tests/onnx2circom/test_comp.py
+++ b/tests/onnx2circom/test_comp.py
@@ -3,18 +3,22 @@ import torch.nn as nn
 
 from .utils import compile_and_check, compile_and_check_mult
 
-
+# two tensor stuffs
 def test_onnx_to_circom(tmp_path):
-    data = torch.tensor(
-        [32],
+    data_1 = torch.tensor(
+        [32, 8, 8],
+        dtype = torch.float32,
+    ).reshape(1, -1, 1)
+    data_2 = torch.tensor(
+        [3, 3, 5],
         dtype = torch.float32,
     ).reshape(1, -1, 1)
     class Model(nn.Module):
-        def forward(self, x):
-            return torch.log(x)
+        def forward(self, x, y):
+            return x+y
             m = torch.mean(x)  # 16
             s = torch.sum(x)  # 48
             l = torch.log(x)  # 5,3,3
             return m*s+l #773, 771, 771
 
-    compile_and_check(Model, data, tmp_path)
+    compile_and_check_mult(Model, (data_1,data_2), tmp_path)

--- a/tests/onnx2circom/test_onnx_to_circom.py
+++ b/tests/onnx2circom/test_onnx_to_circom.py
@@ -1,17 +1,16 @@
 import torch
 import torch.nn as nn
 
-from .utils import compile_and_check, compile_and_check_mult
+from .utils import compile_and_check
 
 
 def test_onnx_to_circom(tmp_path):
     data = torch.tensor(
-        [32],
+        [32, 8, 8],
         dtype = torch.float32,
     ).reshape(1, -1, 1)
     class Model(nn.Module):
         def forward(self, x):
-            return torch.log(x)
             m = torch.mean(x)  # 16
             s = torch.sum(x)  # 48
             l = torch.log(x)  # 5,3,3

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -3,34 +3,34 @@ import torch.nn as nn
 
 import pytest
 
-from .utils import compile_and_check, compile_and_check_mult
+from .utils import compile_and_check
 
 
 @pytest.mark.parametrize(
     "func",
     [
-        # pytest.param(lambda x: x + 4, id="x + 4"),
-        # pytest.param(lambda x: 4 + x, id="4 + x"),
-        # pytest.param(lambda x: x - 4, id="x - 4"),
-        # pytest.param(lambda x: 4 - x, id="4 - x"),
-        # pytest.param(lambda x: torch.mean(x) + 4, id="mean(x) + 4"),
-        # pytest.param(lambda x: 4 + torch.mean(x), id="4 + mean(x)"),
-        # pytest.param(lambda x: torch.mean(x) - 4, id="mean(x) - 4"),
-        # pytest.param(lambda x: 4 - torch.mean(x), id="4 - mean(x)"),
-        # pytest.param(lambda x: torch.mean(x) + torch.sum(x), id="mean(x) + sum(x)"),
-        # pytest.param(lambda x: torch.mean(x) - torch.sum(x), id="mean(x) - sum(x)"),
-        # pytest.param(lambda x: torch.mean(x) + x, id="mean(x) + x"),
-        # pytest.param(lambda x: x + torch.mean(x), id="x + mean(x)"),
-        # pytest.param(lambda x: torch.mean(x) - x, id="mean(x) - x"),
-        # pytest.param(lambda x: x - torch.mean(x), id="x - mean(x)"),
-        # `log` is slower. We can test non-slow ones with `pytest -m "not slow"`
+        pytest.param(lambda x: x + 4, id="x + 4"),
+        pytest.param(lambda x: 4 + x, id="4 + x"),
+        pytest.param(lambda x: x - 4, id="x - 4"),
+        pytest.param(lambda x: 4 - x, id="4 - x"),
+        pytest.param(lambda x: torch.mean(x) + 4, id="mean(x) + 4"),
+        pytest.param(lambda x: 4 + torch.mean(x), id="4 + mean(x)"),
+        pytest.param(lambda x: torch.mean(x) - 4, id="mean(x) - 4"),
+        pytest.param(lambda x: 4 - torch.mean(x), id="4 - mean(x)"),
+        pytest.param(lambda x: torch.mean(x) + torch.sum(x), id="mean(x) + sum(x)"),
+        pytest.param(lambda x: torch.mean(x) - torch.sum(x), id="mean(x) - sum(x)"),
+        pytest.param(lambda x: torch.mean(x) + x, id="mean(x) + x"),
+        pytest.param(lambda x: x + torch.mean(x), id="x + mean(x)"),
+        pytest.param(lambda x: torch.mean(x) - x, id="mean(x) - x"),
+        pytest.param(lambda x: x - torch.mean(x), id="x - mean(x)"),
+        # # `log` is slower. We can test non-slow ones with `pytest -m "not slow"`
         pytest.param(lambda x: x + torch.log(x), id="x + log(x)"),
-        # pytest.param(lambda x: torch.log(x) + x, id="log(x) + x"),
-        # pytest.param(lambda x: x - torch.log(x), id="x - log(x)"),
-        # pytest.param(lambda x: torch.log(x) - x, id="log(x) - x"),
-        # pytest.param(lambda x: torch.mean(x) + torch.log(x), id="mean(x) + log(x)"),
-        # pytest.param(lambda x: torch.log(x) + torch.mean(x), id="log(x) + mean(x)"),
-        # pytest.param(lambda x: torch.mean(x) - torch.log(x), id="mean(x) - log(x)"),
+        pytest.param(lambda x: torch.log(x) + x, id="log(x) + x"),
+        pytest.param(lambda x: x - torch.log(x), id="x - log(x)"),
+        pytest.param(lambda x: torch.log(x) - x, id="log(x) - x"),
+        pytest.param(lambda x: torch.mean(x) + torch.log(x), id="mean(x) + log(x)"),
+        pytest.param(lambda x: torch.log(x) + torch.mean(x), id="log(x) + mean(x)"),
+        pytest.param(lambda x: torch.mean(x) - torch.log(x), id="mean(x) - log(x)"),
     ]
 )
 def test_two_inputs(func, tmp_path):
@@ -42,4 +42,4 @@ def test_two_inputs(func, tmp_path):
         def forward(self, x):
             return func(x)
 
-    compile_and_check_mult(Model, data, tmp_path)
+    compile_and_check(Model, data, tmp_path)

--- a/tests/onnx2circom/test_two_inputs.py
+++ b/tests/onnx2circom/test_two_inputs.py
@@ -3,34 +3,34 @@ import torch.nn as nn
 
 import pytest
 
-from .utils import compile_and_check
+from .utils import compile_and_check, compile_and_check_mult
 
 
 @pytest.mark.parametrize(
     "func",
     [
-        pytest.param(lambda x: x + 4, id="x + 4"),
-        pytest.param(lambda x: 4 + x, id="4 + x"),
-        pytest.param(lambda x: x - 4, id="x - 4"),
-        pytest.param(lambda x: 4 - x, id="4 - x"),
-        pytest.param(lambda x: torch.mean(x) + 4, id="mean(x) + 4"),
-        pytest.param(lambda x: 4 + torch.mean(x), id="4 + mean(x)"),
-        pytest.param(lambda x: torch.mean(x) - 4, id="mean(x) - 4"),
-        pytest.param(lambda x: 4 - torch.mean(x), id="4 - mean(x)"),
-        pytest.param(lambda x: torch.mean(x) + torch.sum(x), id="mean(x) + sum(x)"),
-        pytest.param(lambda x: torch.mean(x) - torch.sum(x), id="mean(x) - sum(x)"),
-        pytest.param(lambda x: torch.mean(x) + x, id="mean(x) + x"),
-        pytest.param(lambda x: x + torch.mean(x), id="x + mean(x)"),
-        pytest.param(lambda x: torch.mean(x) - x, id="mean(x) - x"),
-        pytest.param(lambda x: x - torch.mean(x), id="x - mean(x)"),
+        # pytest.param(lambda x: x + 4, id="x + 4"),
+        # pytest.param(lambda x: 4 + x, id="4 + x"),
+        # pytest.param(lambda x: x - 4, id="x - 4"),
+        # pytest.param(lambda x: 4 - x, id="4 - x"),
+        # pytest.param(lambda x: torch.mean(x) + 4, id="mean(x) + 4"),
+        # pytest.param(lambda x: 4 + torch.mean(x), id="4 + mean(x)"),
+        # pytest.param(lambda x: torch.mean(x) - 4, id="mean(x) - 4"),
+        # pytest.param(lambda x: 4 - torch.mean(x), id="4 - mean(x)"),
+        # pytest.param(lambda x: torch.mean(x) + torch.sum(x), id="mean(x) + sum(x)"),
+        # pytest.param(lambda x: torch.mean(x) - torch.sum(x), id="mean(x) - sum(x)"),
+        # pytest.param(lambda x: torch.mean(x) + x, id="mean(x) + x"),
+        # pytest.param(lambda x: x + torch.mean(x), id="x + mean(x)"),
+        # pytest.param(lambda x: torch.mean(x) - x, id="mean(x) - x"),
+        # pytest.param(lambda x: x - torch.mean(x), id="x - mean(x)"),
         # `log` is slower. We can test non-slow ones with `pytest -m "not slow"`
         pytest.param(lambda x: x + torch.log(x), id="x + log(x)"),
-        pytest.param(lambda x: torch.log(x) + x, id="log(x) + x"),
-        pytest.param(lambda x: x - torch.log(x), id="x - log(x)"),
-        pytest.param(lambda x: torch.log(x) - x, id="log(x) - x"),
-        pytest.param(lambda x: torch.mean(x) + torch.log(x), id="mean(x) + log(x)"),
-        pytest.param(lambda x: torch.log(x) + torch.mean(x), id="log(x) + mean(x)"),
-        pytest.param(lambda x: torch.mean(x) - torch.log(x), id="mean(x) - log(x)"),
+        # pytest.param(lambda x: torch.log(x) + x, id="log(x) + x"),
+        # pytest.param(lambda x: x - torch.log(x), id="x - log(x)"),
+        # pytest.param(lambda x: torch.log(x) - x, id="log(x) - x"),
+        # pytest.param(lambda x: torch.mean(x) + torch.log(x), id="mean(x) + log(x)"),
+        # pytest.param(lambda x: torch.log(x) + torch.mean(x), id="log(x) + mean(x)"),
+        # pytest.param(lambda x: torch.mean(x) - torch.log(x), id="mean(x) - log(x)"),
     ]
 )
 def test_two_inputs(func, tmp_path):
@@ -42,4 +42,4 @@ def test_two_inputs(func, tmp_path):
         def forward(self, x):
             return func(x)
 
-    compile_and_check(Model, data, tmp_path)
+    compile_and_check_mult(Model, data, tmp_path)

--- a/tests/onnx2circom/test_where.py
+++ b/tests/onnx2circom/test_where.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+
+from .utils import compile_and_check
+
+def test_where(tmp_path):
+    data_1 = torch.tensor(
+        [32, 8, 7],
+        dtype = torch.float32,
+    ).reshape(1, -1, 1)
+    data_2 = torch.tensor(
+        [3, 11, 9],
+        dtype = torch.float32,
+    ).reshape(1, -1, 1)
+    class Model(nn.Module):
+        def forward(self,x,y):
+            # Everything works till there's swap when doing this kind of stuff: x and y somehow swap!
+            return torch.where(x>8, x, y-1)
+            # But these below works!
+            return torch.where(x>8, x, y)
+            return torch.where(torch.logical_or(x<y, x>20), x, y)
+            return torch.where(x>8, x, y)
+            return torch.where(x>=8, x, 11)
+            return torch.where(x>=8, 0, 9)
+
+    compile_and_check(Model, (data_1, data_2), tmp_path)

--- a/tests/onnx2circom/test_where.py
+++ b/tests/onnx2circom/test_where.py
@@ -14,7 +14,7 @@ def test_where(tmp_path):
     ).reshape(1, -1, 1)
     class Model(nn.Module):
         def forward(self,x,y):
-            # Everything works till there's swap when doing this kind of stuff: x and y somehow swap!
+            # Just this example that the result are as if the x and y are swapped
             return torch.where(x>8, x, y-1)
             # But these below works!
             return torch.where(x>8, x, y)

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -12,8 +12,8 @@ from zkstats.arithc_to_bristol import parse_arithc_json
 from zkstats.backends.mpspdz import generate_mpspdz_circuit, generate_mpspdz_inputs_for_party, run_mpspdz_circuit
 
 
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
-MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
+CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/jernkun/Desktop/circom-2-arithc')
+MP_SPDZ_PROJECT_ROOT = Path('/Users/jernkun/Desktop/MP-SPDZ')
 
 
 def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path: Path):
@@ -162,4 +162,167 @@ def torch_model_to_onnx(model_type: Type[nn.Module], data: torch.Tensor, output_
                         output_names = ['output'], # the model's output names
                         dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes
                                         'output' : {0 : 'batch_size'}})
+
+
+
+#  For generalized multiple tensor input
+    
+def compile_and_check_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor], tmp_path: Path):
+    # output_path = tmp_path
+    # Don't use tmp_path for now for easier debugging
+    # So you should see all generated files in `output_path`
+    output_path = Path(__file__).parent / 'out'
+    print(f"!@# {output_path=}")
+    output_path.mkdir(parents=True, exist_ok=True)
+    onnx_path = output_path / 'model.onnx'
+    model_name = onnx_path.stem
+    keras_path = onnx_path.parent / f"{model_name}.keras"
+    assert onnx_path.stem == keras_path.stem
+    print(f"!@# {keras_path=}")
+    circom_path = output_path / f"{model_name}.circom"
+    print(f"!@# {circom_path=}")
+
+    print("Running torch model...")
+    output_torch = run_torch_model_mult(model_type, data)
+    print("!@# output_torch=", output_torch)
+
+    print("Transforming torch model to onnx...")
+    torch_model_to_onnx_mult(model_type, data, onnx_path)
+    assert onnx_path.exists() is True, f"The output file {onnx_path} does not exist."
+    print("Transforming onnx model to circom...")
+    onnx_to_circom(onnx_path, circom_path)
+    assert circom_path.exists() is True, f"The output file {circom_path} does not exist."
+
+    arithc_path = output_path / f"{model_name}.json"
+    # Compile with circom-2-arithc compiler
+    code = os.system(f"cd {CIRCOM_2_ARITHC_PROJECT_ROOT} && ./target/release/circom --input {circom_path} --output {output_path}")
+    if code != 0:
+        raise ValueError(f"Failed to compile circom. Error code: {code}")
+    arithc_path = output_path / f"{model_name}.json"
+    assert arithc_path.exists() is True, f"The output file {arithc_path} does not exist."
+
+    print("!@# circom_path=", circom_path)
+    print("!@# arithc_path=", arithc_path)
+
+    bristol_path = output_path / f"{model_name}.txt"
+    circuit_info_path = output_path / f"{model_name}.circuit_info.json"
+    parse_arithc_json(arithc_path, bristol_path, circuit_info_path)
+    assert bristol_path.exists() is True, f"The output file {bristol_path} does not exist."
+    assert circuit_info_path.exists() is True, f"The output file {circuit_info_path} does not exist."
+    print("!@# bristol_path=", bristol_path)
+    print("!@# circuit_info_path=", circuit_info_path)
+
+    # Mark every input as from 0
+    with open(circuit_info_path, 'r') as f:
+        circuit_info = json.load(f)
+    input_name_to_wire_index = circuit_info['input_name_to_wire_index']
+    output_name_to_wire_index = circuit_info['output_name_to_wire_index']
+    input_names = list(input_name_to_wire_index.keys())
+    output_names = list(output_name_to_wire_index.keys())
+    print("!@# input_names=", input_names)
+
+    num_parties = 2
+    # TODO: This should come from users. Here we just set up a config json
+    # for convenience (which input is from which party). Now just put every input to party 0.
+    # Assume the input data is a 1-d tensor
+    mpc_settings_path = output_path / f"{model_name}.mpc_settings.json"
+    mpc_settings_path.parent.mkdir(parents=True, exist_ok=True)
+    # party 0 is alice, having input a, and output a_add_b, a_mul_c are revealed to
+    # party 1 is bob, having input b, and output a_add_b, a_mul_c are revealed to
+    # [
+    #     {
+    #         "name": "alice",
+    #         "inputs": ["a"],
+    #         "outputs": ["a_add_b", "a_mul_c"]
+    #     },
+    #     {
+    #         "name": "bob",
+    #         "inputs": ["b"],
+    #         "outputs": ["a_add_b", "a_mul_c"]
+    #     }
+    # ]
+    with open(mpc_settings_path, 'w') as f:
+        json.dump([
+            {
+                "name": "alice",
+                "inputs": input_names,  # All inputs are from party 0
+                "outputs": output_names,  # Party 0 can see all outputs
+            },
+            {
+                "name": "bob",
+                "inputs": [],  # No input is from party 1
+                "outputs": output_names,  # Party 1 can see all outputs
+            }
+        ], f, indent=4)
+
+    print("!@# mpc_settings_path=", mpc_settings_path)
+
+    # Prepare data for party 0
+    # data_list = data.reshape(-1)
+    data_list = []
+    for data_tensor in data:
+        data_list+=(data_tensor.reshape(-1).tolist())
+    # data_list = 
+    input_paths = [output_path / f"{model_name}_party_{i}.inputs.json" for i in range(num_parties)]
+    input_paths[0].parent.mkdir(parents=True, exist_ok=True)
+    with open(input_paths[0], 'w') as f:
+        json.dump({
+            name: int(x) for name, x in zip(input_names, data_list)
+        }, f, indent=4)
+    # input 1 is empty
+    with open(input_paths[1], 'w') as f:
+        json.dump({}, f)
+
+    # Run MP-SPDZ
+    mpspdz_circuit_path = generate_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, bristol_path, circuit_info_path, mpc_settings_path)
+    for party in range(num_parties):
+        input_json_for_party_path = output_path / f"{model_name}_party_{party}.inputs.json"
+        mpspdz_input_path = generate_mpspdz_inputs_for_party(
+            MP_SPDZ_PROJECT_ROOT,
+            party,
+            input_json_for_party_path,
+            circuit_info_path,
+            mpc_settings_path,
+        )
+        print(f"Party {party} input path: {mpspdz_input_path}")
+    print(f"Running mp-spdz circuit {mpspdz_circuit_path}...")
+    # TODO: parse output from MP-SPDZ and compare with torch output
+    run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
+
+
+def run_torch_model_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor]) -> torch.Tensor:
+    model = model_type()
+    output_torch = model.forward(*data)
+    # untuple the result: if the result is [x], return x
+    shape = output_torch.shape
+    # if it is a 0-d tensor, return it directly
+    if len(shape) == 0:
+        return output_torch
+    # if it is a 1-d tensor with one element, return the element directly
+    elif len(shape) == 1 and shape[0] == 1:
+        return output_torch[0]
+    else:
+        return output_torch
+
+
+def torch_model_to_onnx_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor], output_onnx_path: Path):
+  model = model_type()
+  input_names = []
+  dynamic_axes = {}
+  for i in range(len(data)):
+    input_index = "input"+str(i+1)
+    input_names.append(input_index)
+    dynamic_axes[input_index] = {0 : 'batch_size'}
+  dynamic_axes["output"] = {0 : 'batch_size'}
+
+  # Export the model
+  torch.onnx.export(model,               # model being run
+                      data,                   # model input (or a tuple for multiple inputs)
+                      output_onnx_path,            # where to save the model (can be a file or file-like object)
+                      export_params=True,        # store the trained parameter weights inside the model file
+                      opset_version=11,          # the ONNX version to export the model to
+                      do_constant_folding=True,  # whether to execute constant folding for optimization
+                      input_names = input_names,   # the model's input names
+                      output_names = ['output'], # the model's output names
+                      dynamic_axes=dynamic_axes)
 

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -15,8 +15,9 @@ from zkstats.backends.mpspdz import generate_mpspdz_circuit, generate_mpspdz_inp
 CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/jernkun/Desktop/circom-2-arithc')
 MP_SPDZ_PROJECT_ROOT = Path('/Users/jernkun/Desktop/MP-SPDZ')
 
-
-def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path: Path):
+#  For generalized multiple tensor input
+    
+def compile_and_check(model_type: Type[nn.Module], data: tuple[torch.Tensor], tmp_path: Path):
     # output_path = tmp_path
     # Don't use tmp_path for now for easier debugging
     # So you should see all generated files in `output_path`
@@ -68,157 +69,7 @@ def compile_and_check(model_type: Type[nn.Module], data: torch.Tensor, tmp_path:
     output_name_to_wire_index = circuit_info['output_name_to_wire_index']
     input_names = list(input_name_to_wire_index.keys())
     output_names = list(output_name_to_wire_index.keys())
-    print("!@# input_names=", input_names)
-
-    num_parties = 2
-    # TODO: This should come from users. Here we just set up a config json
-    # for convenience (which input is from which party). Now just put every input to party 0.
-    # Assume the input data is a 1-d tensor
-    mpc_settings_path = output_path / f"{model_name}.mpc_settings.json"
-    mpc_settings_path.parent.mkdir(parents=True, exist_ok=True)
-    # party 0 is alice, having input a, and output a_add_b, a_mul_c are revealed to
-    # party 1 is bob, having input b, and output a_add_b, a_mul_c are revealed to
-    # [
-    #     {
-    #         "name": "alice",
-    #         "inputs": ["a"],
-    #         "outputs": ["a_add_b", "a_mul_c"]
-    #     },
-    #     {
-    #         "name": "bob",
-    #         "inputs": ["b"],
-    #         "outputs": ["a_add_b", "a_mul_c"]
-    #     }
-    # ]
-    with open(mpc_settings_path, 'w') as f:
-        json.dump([
-            {
-                "name": "alice",
-                "inputs": input_names,  # All inputs are from party 0
-                "outputs": output_names,  # Party 0 can see all outputs
-            },
-            {
-                "name": "bob",
-                "inputs": [],  # No input is from party 1
-                "outputs": output_names,  # Party 1 can see all outputs
-            }
-        ], f, indent=4)
-
-    print("!@# mpc_settings_path=", mpc_settings_path)
-
-    # Prepare data for party 0
-    data_list = data.reshape(-1)
-    input_paths = [output_path / f"{model_name}_party_{i}.inputs.json" for i in range(num_parties)]
-    input_paths[0].parent.mkdir(parents=True, exist_ok=True)
-    with open(input_paths[0], 'w') as f:
-        json.dump({
-            name: int(x) for name, x in zip(input_names, data_list.tolist())
-        }, f, indent=4)
-    # input 1 is empty
-    with open(input_paths[1], 'w') as f:
-        json.dump({}, f)
-
-    # Run MP-SPDZ
-    mpspdz_circuit_path = generate_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, bristol_path, circuit_info_path, mpc_settings_path)
-    for party in range(num_parties):
-        input_json_for_party_path = output_path / f"{model_name}_party_{party}.inputs.json"
-        mpspdz_input_path = generate_mpspdz_inputs_for_party(
-            MP_SPDZ_PROJECT_ROOT,
-            party,
-            input_json_for_party_path,
-            circuit_info_path,
-            mpc_settings_path,
-        )
-        print(f"Party {party} input path: {mpspdz_input_path}")
-    print(f"Running mp-spdz circuit {mpspdz_circuit_path}...")
-    # TODO: parse output from MP-SPDZ and compare with torch output
-    run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
-
-
-def run_torch_model(model_type: Type[nn.Module], data: torch.Tensor) -> torch.Tensor:
-    model = model_type()
-    output_torch = model.forward(data)
-    # untuple the result: if the result is [x], return x
-    shape = output_torch.shape
-    # if it is a 0-d tensor, return it directly
-    if len(shape) == 0:
-        return output_torch
-    # if it is a 1-d tensor with one element, return the element directly
-    elif len(shape) == 1 and shape[0] == 1:
-        return output_torch[0]
-    else:
-        return output_torch
-
-
-def torch_model_to_onnx(model_type: Type[nn.Module], data: torch.Tensor, output_onnx_path: Path):
-    model = model_type()
-    torch.onnx.export(model,               # model being run
-                        data,                   # model input (or a tuple for multiple inputs)
-                        output_onnx_path,            # where to save the model (can be a file or file-like object)
-                        export_params=True,        # store the trained parameter weights inside the model file
-                        opset_version=11,          # the ONNX version to export the model to
-                        do_constant_folding=True,  # whether to execute constant folding for optimization
-                        input_names = ['input'],   # the model's input names
-                        output_names = ['output'], # the model's output names
-                        dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes
-                                        'output' : {0 : 'batch_size'}})
-
-
-
-#  For generalized multiple tensor input
-    
-def compile_and_check_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor], tmp_path: Path):
-    # output_path = tmp_path
-    # Don't use tmp_path for now for easier debugging
-    # So you should see all generated files in `output_path`
-    output_path = Path(__file__).parent / 'out'
-    print(f"!@# {output_path=}")
-    output_path.mkdir(parents=True, exist_ok=True)
-    onnx_path = output_path / 'model.onnx'
-    model_name = onnx_path.stem
-    keras_path = onnx_path.parent / f"{model_name}.keras"
-    assert onnx_path.stem == keras_path.stem
-    print(f"!@# {keras_path=}")
-    circom_path = output_path / f"{model_name}.circom"
-    print(f"!@# {circom_path=}")
-
-    print("Running torch model...")
-    output_torch = run_torch_model_mult(model_type, data)
-    print("!@# output_torch=", output_torch)
-
-    print("Transforming torch model to onnx...")
-    torch_model_to_onnx_mult(model_type, data, onnx_path)
-    assert onnx_path.exists() is True, f"The output file {onnx_path} does not exist."
-    print("Transforming onnx model to circom...")
-    onnx_to_circom(onnx_path, circom_path)
-    assert circom_path.exists() is True, f"The output file {circom_path} does not exist."
-
-    arithc_path = output_path / f"{model_name}.json"
-    # Compile with circom-2-arithc compiler
-    code = os.system(f"cd {CIRCOM_2_ARITHC_PROJECT_ROOT} && ./target/release/circom --input {circom_path} --output {output_path}")
-    if code != 0:
-        raise ValueError(f"Failed to compile circom. Error code: {code}")
-    arithc_path = output_path / f"{model_name}.json"
-    assert arithc_path.exists() is True, f"The output file {arithc_path} does not exist."
-
-    print("!@# circom_path=", circom_path)
-    print("!@# arithc_path=", arithc_path)
-
-    bristol_path = output_path / f"{model_name}.txt"
-    circuit_info_path = output_path / f"{model_name}.circuit_info.json"
-    parse_arithc_json(arithc_path, bristol_path, circuit_info_path)
-    assert bristol_path.exists() is True, f"The output file {bristol_path} does not exist."
-    assert circuit_info_path.exists() is True, f"The output file {circuit_info_path} does not exist."
-    print("!@# bristol_path=", bristol_path)
-    print("!@# circuit_info_path=", circuit_info_path)
-
-    # Mark every input as from 0
-    with open(circuit_info_path, 'r') as f:
-        circuit_info = json.load(f)
-    input_name_to_wire_index = circuit_info['input_name_to_wire_index']
-    output_name_to_wire_index = circuit_info['output_name_to_wire_index']
-    input_names = list(input_name_to_wire_index.keys())
-    output_names = list(output_name_to_wire_index.keys())
+    print("!@# input_name_to_wire_index=", input_name_to_wire_index)
     print("!@# input_names=", input_names)
 
     num_parties = 2
@@ -290,7 +141,7 @@ def compile_and_check_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor
     run_mpspdz_circuit(MP_SPDZ_PROJECT_ROOT, mpspdz_circuit_path)
 
 
-def run_torch_model_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor]) -> torch.Tensor:
+def run_torch_model(model_type: Type[nn.Module], data: tuple[torch.Tensor]) -> torch.Tensor:
     model = model_type()
     output_torch = model.forward(*data)
     # untuple the result: if the result is [x], return x
@@ -305,7 +156,7 @@ def run_torch_model_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor])
         return output_torch
 
 
-def torch_model_to_onnx_mult(model_type: Type[nn.Module], data: tuple[torch.Tensor], output_onnx_path: Path):
+def torch_model_to_onnx(model_type: Type[nn.Module], data: tuple[torch.Tensor], output_onnx_path: Path):
   model = model_type()
   input_names = []
   dynamic_axes = {}

--- a/zkstats/onnx2circom/keras2circom/keras2circom/model.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/model.py
@@ -24,7 +24,7 @@ class Input:
     # If it's a constant, value is the value of the constant. Else, it's None
     value: typing.Optional[float]
     # is it keras_tensor in form of no shape i.e. shape = () 
-    # is_keras_constant: bool
+    is_keras_constant: bool
 
 
 # read each layer in a model and convert it to a class called Layer
@@ -48,13 +48,14 @@ class Layer:
         self.config = _config
         self.inputs = []
         list_inputs = _config['node_inputs']
-        # is_keras_constant = False
+        
 
         index = 0
         for ele_name in list_inputs:
             # non-constant: {'class_name': '__keras_tensor__', 'config': {'shape': [1, 3, 1], 'dtype': 'float32', 'keras_history': ['input_layer', 0, 0]}, 'name': 'input_layer'},
             # non-constant: {'class_name': '__keras_tensor__', 'config': {'shape': [], 'dtype': 'float32', 'keras_history': ['tf_reducemean', 0, 0]}},
             # constant: 3.0
+            is_keras_constant = False
             config_ele = _config['tensor_grap'][ele_name]
             # it's not a constant, add the name of the input
             is_non_constant = isinstance(config_ele, dict) and config_ele["class_name"]=='__keras_tensor__'
@@ -69,7 +70,7 @@ class Layer:
                         input_shape = (_inputs[1-index]).shape[:-1]
                     else:
                         input_shape =(1,1)
-                    # is_keras_constant = True
+                    is_keras_constant = True
                 index += 1
             # it's constant. assume it's a float
             else:
@@ -79,13 +80,14 @@ class Layer:
                     input_shape = (_inputs[0]).shape[:-1]
                 else:
                     input_shape =(1,1)
+                
             self.inputs.append(
                 Input(
                     is_constant=not is_non_constant,
                     shape=input_shape,
                     name=name,
                     value=value,
-                    # is_keras_constant=is_keras_constant
+                    is_keras_constant=is_keras_constant
                 )
             )
 

--- a/zkstats/onnx2circom/keras2circom/keras2circom/model.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/model.py
@@ -23,6 +23,8 @@ class Input:
     name: typing.Optional[str]
     # If it's a constant, value is the value of the constant. Else, it's None
     value: typing.Optional[float]
+    # is it keras_tensor in form of no shape i.e. shape = () 
+    # is_keras_constant: bool
 
 
 # read each layer in a model and convert it to a class called Layer
@@ -46,25 +48,28 @@ class Layer:
         self.config = _config
         self.inputs = []
         list_inputs = _config['node_inputs']
+        # is_keras_constant = False
 
         index = 0
         for ele_name in list_inputs:
             # non-constant: {'class_name': '__keras_tensor__', 'config': {'shape': [1, 3, 1], 'dtype': 'float32', 'keras_history': ['input_layer', 0, 0]}, 'name': 'input_layer'},
+            # non-constant: {'class_name': '__keras_tensor__', 'config': {'shape': [], 'dtype': 'float32', 'keras_history': ['tf_reducemean', 0, 0]}},
             # constant: 3.0
             config_ele = _config['tensor_grap'][ele_name]
             # it's not a constant, add the name of the input
             is_non_constant = isinstance(config_ele, dict) and config_ele["class_name"]=='__keras_tensor__'
-            # if it's constant, get the shape from non-constant input
             if is_non_constant:
                 name = _inputs[index].name
                 value = None
                 input_shape = tuple(config_ele['config']['shape'])
+                # if it's keras tensor resulting in constant, get the shape from non-constant input
                 if input_shape == ():
                     # if there are more than 1 inputs like `TFAdd`, we need to get the shape of the other input
                     if len(_inputs)==2 and len(_inputs[1-index].shape)>=2:
                         input_shape = (_inputs[1-index]).shape[:-1]
                     else:
                         input_shape =(1,1)
+                    # is_keras_constant = True
                 index += 1
             # it's constant. assume it's a float
             else:
@@ -80,6 +85,7 @@ class Layer:
                     shape=input_shape,
                     name=name,
                     value=value,
+                    # is_keras_constant=is_keras_constant
                 )
             )
 

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -37,6 +37,14 @@ template TFDiv(nElements) {
     }
 }
 
+template TFEqual(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i] == right[i];
+    }
+}
 
 template TFReduceSum(nInputs) {
     signal input in[nInputs];

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -46,6 +46,70 @@ template TFEqual(nElements) {
     }
 }
 
+template TFGreater(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i] > right[i];
+    }
+}
+
+template TFLess(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i] < right[i];
+    }
+}
+
+template TFNot(nElements) {
+    signal input in[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== 1-in[i];
+    }
+}
+
+template TFAnd(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i]*right[i];
+    }
+}
+
+template TFOr(nElements) {
+    signal input left[nElements];
+    signal input right[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== left[i] + right[i] - left[i]*right[i];
+    }
+}
+
+template TFCast(nElements){
+    signal input in[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== in[i];
+    }
+}
+
+template TFWhere(nElements) {
+    // condition
+    signal input condition[nElements];
+    signal input res_if_true[nElements];
+    signal input res_if_false[nElements];
+    signal output out[nElements];
+
+    for (var i = 0; i < nElements; i++) {
+        out[i] <== (condition[i] * res_if_true[i]) + ((1 - condition[i]) * res_if_false[i]);
+    }
+}
+
 template TFReduceSum(nInputs) {
     signal input in[nInputs];
     signal output out;

--- a/zkstats/onnx2circom/onnx2keras/layers/mathematics_layers.py
+++ b/zkstats/onnx2circom/onnx2keras/layers/mathematics_layers.py
@@ -267,28 +267,69 @@ class TFWhere(keras.layers.Layer):
     
 @OPERATOR.register_operator("Not")
 class TFNot(keras.layers.Layer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
         super().__init__()
+        self.tensor_grap = tensor_grap
+        self.node_weights = node_weights
+        self.node_inputs = node_inputs
+        self.node_attribute = node_attribute
 
 
     def call(self,input, *args, **kwargs):
         return keras.ops.logical_not(input)
 
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "tensor_grap":self.tensor_grap,
+            'node_weights':self.node_weights,
+            'node_inputs':self.node_inputs,
+            'node_attribute':self.node_attribute,
+        })
+        return config
+    
 @OPERATOR.register_operator("And")
 class TFAnd(keras.layers.Layer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
         super().__init__()
-
+        self.tensor_grap = tensor_grap
+        self.node_weights = node_weights
+        self.node_inputs = node_inputs
+        self.node_attribute = node_attribute
     def call(self,  *args, **kwargs):
         return keras.ops.logical_and(args[0], args[1])
+    
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "tensor_grap":self.tensor_grap,
+            'node_weights':self.node_weights,
+            'node_inputs':self.node_inputs,
+            'node_attribute':self.node_attribute,
+        })
+        return config
 
 @OPERATOR.register_operator("Or")
 class TFOr(keras.layers.Layer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
         super().__init__()
+        self.tensor_grap = tensor_grap
+        self.node_weights = node_weights
+        self.node_inputs = node_inputs
+        self.node_attribute = node_attribute
 
     def call(self,  *args, **kwargs):
         return keras.ops.logical_or(args[0], args[1])
+    
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "tensor_grap":self.tensor_grap,
+            'node_weights':self.node_weights,
+            'node_inputs':self.node_inputs,
+            'node_attribute':self.node_attribute,
+        })
+        return config
 
 
 @OPERATOR.register_operator("Abs")


### PR DESCRIPTION
- Fix keras_tensor that results in single number but still preserve the dimension e.g. TFAdd(1), it should be assigned in for-loop as if constant when used as input, so we will enforce its index to be 0. 
- Make compile_and_check support general multiple-tensors input for test
- Now support boolean-related operations as follows

    Equal, Lessthan, Greaterthan (including <=, >= as well)
    torch.logical_not
    torch.logical_or
    torch.logical_and
    All these above shown in n test_comp.py

    torch.where (see note below)
- Modify Mpc.circom & layer to contain config accordingly

Note:
- Now, no enforcement that the inputs for AND, OR, NOT must be boolean yet. Since we cannot define === in circom-2-arith 
- TFCast in mpc.circom —> do nothing yet for now —> since now we just do all in integer, and no concept of boolean in circom yet. Can change once we introduce floating point and their scale
- Where operations is almost done. However, please take a look at test_where.py where most tests pass except one that somehow input data swap places. I suspect it may come from MPSPDZ parser since the circom and onnx file are correct. @mhchia Could you help investigate? Thanks :))