### PR TITLE
Skeleton for non-witness approach

### DIFF
--- a/tests/onnx2circom/test_zkstats_computation.py
+++ b/tests/onnx2circom/test_zkstats_computation.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn as nn
+
+from .utils import compile_and_run_mpspdz
+
+from zkstats.computation import State, computation_to_model
+
+
+def computation(state: State, args: list[torch.Tensor]):
+    x = args[0]
+    # y = args[1]
+    # z = args[2]
+    return state.mean(x)
+
+
+# two tensor stuffs
+def test_computation(tmp_path):
+    data_1 = torch.tensor(
+        [32, 8, 8],
+        dtype = torch.float32,
+    ).reshape(1, -1, 1)
+
+    precal_witness_path = tmp_path / "precal_witness_path.json"
+    state, Model = computation_to_model(computation, precal_witness_path, True)
+
+    # class Model(nn.Module):
+    #     def forward(self, *x):
+    #         return torch.mean(x[0])
+
+    compile_and_run_mpspdz(Model, tuple([data_1]), tmp_path)

--- a/tests/onnx2circom/test_zkstats_computation.py
+++ b/tests/onnx2circom/test_zkstats_computation.py
@@ -1,12 +1,13 @@
 import torch
-import torch.nn as nn
+from typing import Type
+
+from zkstats.computation import IState, computation_to_model_mpc
 
 from .utils import compile_and_run_mpspdz
 
-from zkstats.computation import State, computation_to_model
 
 
-def computation(state: State, args: list[torch.Tensor]):
+def computation(state: IState, args: list[torch.Tensor]):
     x = args[0]
     # y = args[1]
     # z = args[2]
@@ -20,11 +21,6 @@ def test_computation(tmp_path):
         dtype = torch.float32,
     ).reshape(1, -1, 1)
 
-    precal_witness_path = tmp_path / "precal_witness_path.json"
-    state, Model = computation_to_model(computation, precal_witness_path, True)
-
-    # class Model(nn.Module):
-    #     def forward(self, *x):
-    #         return torch.mean(x[0])
+    state, Model = computation_to_model_mpc(computation)
 
     compile_and_run_mpspdz(Model, tuple([data_1]), tmp_path)

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -163,6 +163,10 @@ def run_torch_model(model_type: Type[nn.Module], data: tuple[torch.Tensor]) -> t
 
 def torch_model_to_onnx(model_type: Type[nn.Module], data: tuple[torch.Tensor], output_onnx_path: Path):
   model = model_type()
+  try:
+    model.preprocess(data)
+  except AttributeError:
+    pass
   input_names = []
   dynamic_axes = {}
   for i in range(len(data)):

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -163,10 +163,6 @@ def run_torch_model(model_type: Type[nn.Module], data: tuple[torch.Tensor]) -> t
 
 def torch_model_to_onnx(model_type: Type[nn.Module], data: tuple[torch.Tensor], output_onnx_path: Path):
   model = model_type()
-  try:
-    model.preprocess(data)
-  except AttributeError:
-    pass
   input_names = []
   dynamic_axes = {}
   for i in range(len(data)):

--- a/zkstats/computation.py
+++ b/zkstats/computation.py
@@ -365,8 +365,10 @@ def computation_to_model(computation: TComputation, precal_witness_path:str, isP
 
 class MPCState(IState):
     def mean(self, x: torch.Tensor) -> torch.Tensor:
-        # return torch.mean(x[x != MagicNumber])
-        return torch.mean(x)
+        total = torch.sum(torch.where(x != MagicNumber, x, 0.0))
+        size = torch.sum(torch.where(x != MagicNumber, 1.0, 0.0))
+        # TODO: what if size is 0?
+        return total / size
 
     def median(self, x: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError

--- a/zkstats/computation.py
+++ b/zkstats/computation.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from typing import Callable, Type, Optional, Union
 
 import torch
@@ -27,7 +27,116 @@ DEFAULT_ERROR = 0.01
 MagicNumber = 99.999
 
 
-class State:
+class IState(ABC):
+    @abstractmethod
+    def mean(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the mean of the input tensor. The behavior should conform to
+        [statistics.mean](https://docs.python.org/3/library/statistics.html#statistics.mean) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def median(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the median of the input tensor. The behavior should conform to
+        [statistics.median](https://docs.python.org/3/library/statistics.html#statistics.median) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def geometric_mean(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the geometric mean of the input tensor. The behavior should conform to
+        [statistics.geometric_mean](https://docs.python.org/3/library/statistics.html#statistics.geometric_mean) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def harmonic_mean(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the harmonic mean of the input tensor. The behavior should conform to
+        [statistics.harmonic_mean](https://docs.python.org/3/library/statistics.html#statistics.harmonic_mean) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def mode(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the mode of the input tensor. The behavior should conform to
+        [statistics.mode](https://docs.python.org/3/library/statistics.html#statistics.mode) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def pstdev(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the population standard deviation of the input tensor. The behavior should conform to
+        [statistics.pstdev](https://docs.python.org/3/library/statistics.html#statistics.pstdev) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def pvariance(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the population variance of the input tensor. The behavior should conform to
+        [statistics.pvariance](https://docs.python.org/3/library/statistics.html#statistics.pvariance) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def stdev(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the sample standard deviation of the input tensor. The behavior should conform to
+        [statistics.stdev](https://docs.python.org/3/library/statistics.html#statistics.stdev) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def variance(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the sample variance of the input tensor. The behavior should conform to
+        [statistics.variance](https://docs.python.org/3/library/statistics.html#statistics.variance) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def covariance(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the covariance of x and y. The behavior should conform to
+        [statistics.covariance](https://docs.python.org/3/library/statistics.html#statistics.covariance) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def correlation(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the correlation of x and y. The behavior should conform to
+        [statistics.correlation](https://docs.python.org/3/library/statistics.html#statistics.correlation) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def linear_regression(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the linear regression of x and y. The behavior should conform to
+        [statistics.linear_regression](https://docs.python.org/3/library/statistics.html#statistics.linear_regression) in Python standard library.
+        """
+        ...
+
+    @abstractmethod
+    def where(self, _filter: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculate the where operation of x. The behavior should conform to `torch.where` in PyTorch.
+
+        :param _filter: A boolean tensor serves as a filter
+        :param x: A tensor to be filtered
+        :return: filtered tensor
+        """
+        ...
+
+
+class State(IState):
     """
     State is a container for intermediate results of computation.
 
@@ -53,99 +162,44 @@ class State:
         self.current_op_index = 0
 
     def mean(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the mean of the input tensor. The behavior should conform to
-        [statistics.mean](https://docs.python.org/3/library/statistics.html#statistics.mean) in Python standard library.
-        """
         return self._call_op([x], Mean)
 
     def median(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the median of the input tensor. The behavior should conform to
-        [statistics.median](https://docs.python.org/3/library/statistics.html#statistics.median) in Python standard library.
-        """
         return self._call_op([x], Median)
 
     def geometric_mean(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the geometric mean of the input tensor. The behavior should conform to
-        [statistics.geometric_mean](https://docs.python.org/3/library/statistics.html#statistics.geometric_mean) in Python standard library.
-        """
         return self._call_op([x], GeometricMean)
 
     def harmonic_mean(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the harmonic mean of the input tensor. The behavior should conform to
-        [statistics.harmonic_mean](https://docs.python.org/3/library/statistics.html#statistics.harmonic_mean) in Python standard library.
-        """
         return self._call_op([x], HarmonicMean)
 
     def mode(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the mode of the input tensor. The behavior should conform to
-        [statistics.mode](https://docs.python.org/3/library/statistics.html#statistics.mode) in Python standard library.
-        """
         return self._call_op([x], Mode)
 
     def pstdev(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the population standard deviation of the input tensor. The behavior should conform to
-        [statistics.pstdev](https://docs.python.org/3/library/statistics.html#statistics.pstdev) in Python standard library.
-        """
         return self._call_op([x], PStdev)
 
     def pvariance(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the population variance of the input tensor. The behavior should conform to
-        [statistics.pvariance](https://docs.python.org/3/library/statistics.html#statistics.pvariance) in Python standard library.
-        """
         return self._call_op([x], PVariance)
 
     def stdev(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the sample standard deviation of the input tensor. The behavior should conform to
-        [statistics.stdev](https://docs.python.org/3/library/statistics.html#statistics.stdev) in Python standard library.
-        """
         return self._call_op([x], Stdev)
 
     def variance(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the sample variance of the input tensor. The behavior should conform to
-        [statistics.variance](https://docs.python.org/3/library/statistics.html#statistics.variance) in Python standard library.
-        """
         return self._call_op([x], Variance)
 
     def covariance(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the covariance of x and y. The behavior should conform to
-        [statistics.covariance](https://docs.python.org/3/library/statistics.html#statistics.covariance) in Python standard library.
-        """
         return self._call_op([x, y], Covariance)
 
     def correlation(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the correlation of x and y. The behavior should conform to
-        [statistics.correlation](https://docs.python.org/3/library/statistics.html#statistics.correlation) in Python standard library.
-        """
         return self._call_op([x, y], Correlation)
 
     def linear_regression(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the linear regression of x and y. The behavior should conform to
-        [statistics.linear_regression](https://docs.python.org/3/library/statistics.html#statistics.linear_regression) in Python standard library.
-        """
         # hence support only one x for now
         return self._call_op([x, y], Regression)
 
     # WHERE operation
     def where(self, _filter: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-        """
-        Calculate the where operation of x. The behavior should conform to `torch.where` in PyTorch.
-
-        :param _filter: A boolean tensor serves as a filter
-        :param x: A tensor to be filtered
-        :return: filtered tensor
-        """
         return torch.where(_filter, x, x-x+MagicNumber)
 
     def _call_op(self, x: list[torch.Tensor], op_type: Type[Operation]) -> Union[torch.Tensor, tuple[IsResultPrecise, torch.Tensor]]:
@@ -161,7 +215,7 @@ class State:
                     if op_class_str not in self.op_dict:
                         self.precal_witness[op_class_str+"_0"] = [op.result.data.item()]
                         self.op_dict[op_class_str] = 1
-                    else: 
+                    else:
                         self.precal_witness[op_class_str+"_"+str(self.op_dict[op_class_str])] = [op.result.data.item()]
                         self.op_dict[op_class_str]+=1
                 elif isinstance(op, Median):
@@ -177,7 +231,7 @@ class State:
                     if op_class_str not in self.op_dict:
                         self.precal_witness[op_class_str+"_0"] = [op.result.data.item(), op.data_mean.data.item()]
                         self.op_dict[op_class_str] = 1
-                    else: 
+                    else:
                         self.precal_witness[op_class_str+"_"+str(self.op_dict[op_class_str])] = [op.result.data.item(), op.data_mean.data.item()]
                         self.op_dict[op_class_str]+=1
                 elif isinstance(op, Covariance):
@@ -279,7 +333,7 @@ class IModel(nn.Module):
 TComputation = Callable[[State, list[torch.Tensor]], torch.Tensor]
 
 
-def computation_to_model(computation: TComputation, precal_witness_path:str, isProver:bool ,error: float = DEFAULT_ERROR ) -> tuple[State, Type[IModel]]:
+def computation_to_model(computation: TComputation, precal_witness_path:str, isProver: bool, error: float = DEFAULT_ERROR) -> tuple[State, Type[IModel]]:
     """
     Create a torch model from a `computation` function defined by user
     :param computation: A function that takes a State and a list of torch.Tensor, and returns a torch.Tensor
@@ -289,7 +343,7 @@ def computation_to_model(computation: TComputation, precal_witness_path:str, isP
     """
     state = State(error)
     # if it's verifier
-    
+
     state.precal_witness_path= precal_witness_path
     state.isProver = isProver
 
@@ -308,3 +362,52 @@ def computation_to_model(computation: TComputation, precal_witness_path:str, isP
     # print('state:: ', state.aggregate_witness_path)
     return state, Model
 
+
+class MPCState(IState):
+    def mean(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(x[x != MagicNumber])
+
+    def median(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def geometric_mean(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def harmonic_mean(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def mode(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def pstdev(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def pvariance(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def stdev(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def variance(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def covariance(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def correlation(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def linear_regression(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def where(self, _filter: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+
+def computation_to_model_mpc(computation: TComputation) -> tuple[State, Type[IModel]]:
+    state = MPCState()
+
+    class Model(IModel):
+        def forward(self, *x: list[torch.Tensor]) -> torch.Tensor:
+            return computation(state, x)
+    return state, Model

--- a/zkstats/computation.py
+++ b/zkstats/computation.py
@@ -365,7 +365,8 @@ def computation_to_model(computation: TComputation, precal_witness_path:str, isP
 
 class MPCState(IState):
     def mean(self, x: torch.Tensor) -> torch.Tensor:
-        return torch.mean(x[x != MagicNumber])
+        # return torch.mean(x[x != MagicNumber])
+        return torch.mean(x)
 
     def median(self, x: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError

--- a/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/transpiler.py
@@ -22,12 +22,13 @@ from zkstats.onnx2circom.onnx2keras.layers import (
     TFReduceMin,
     TFEqual,
     TFGreater,
-    TFLess, 
+    TFLess,
     TFNot,
     TFCast,
-    TFAnd, 
-    TFOr, 
-    TFWhere
+    TFAnd,
+    TFOr,
+    TFWhere,
+    TFAbs,
     # TFArgMax,
     # TFArgMin,
 )
@@ -55,12 +56,13 @@ SUPPORTED_OPS = [
     TFExp,  # e^n
     TFEqual,
     TFGreater,
-    TFLess, 
+    TFLess,
     TFNot,
     TFAnd,
     TFOr,
-    TFCast, 
-    TFWhere
+    TFCast,
+    TFWhere,
+    TFAbs,
     # TFErf,
 ]
 
@@ -94,7 +96,7 @@ def get_component_args_values(layer: Layer) -> typing.Dict[str, typing.Any]:
         return {'e': 2, 'nInputs': num_elements_in_input_0}
     if is_in_ops(layer.op, [TFReduceSum, TFReduceMean]):
         return {'nInputs': num_elements_in_input_0}
-    if is_in_ops(layer.op, [TFNot, TFCast, TFWhere]):
+    if is_in_ops(layer.op, [TFNot, TFCast, TFWhere, TFAbs]):
         return {'nElements': num_elements_in_input_0}
     # 2 inputs operations
     if is_in_ops(layer.op, [TFAdd, TFSub, TFMul, TFDiv, TFEqual, TFGreater, TFLess, TFAnd, TFOr]):

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -110,6 +110,17 @@ template TFWhere(nElements) {
     }
 }
 
+template TFAbs(nElements) {
+    // condition
+    signal input in[nElements];
+    signal output out[nElements];
+
+    for (var i = 0; i < nElements; i++) {
+        // in[i] > 0 ? in[i] : -in[i]
+        out[i] <== in[i] * (2 * (in[i] >= 0) - 1);
+    }
+}
+
 template TFReduceSum(nInputs) {
     signal input in[nInputs];
     signal output out;

--- a/zkstats/onnx2circom/onnx2keras/layers/mathematics_layers.py
+++ b/zkstats/onnx2circom/onnx2keras/layers/mathematics_layers.py
@@ -33,7 +33,7 @@ def match_tensor(x1:tf.Tensor or np.ndarray, x2:tf.Tensor or np.ndarray):
     if len(x1.shape) != len(x2.shape):
         while len(x2.shape) < len(x1.shape):
             x2 = tf.expand_dims(x2, axis=0)
-    
+
     # new_shape = dimension_utils.shape_NCD_to_NDC_format([i for i in range(len(x2.shape))])
     # x2 = tf.transpose(x2, new_shape)
     return (x2, x1) if f2 else (x1, x2)
@@ -53,7 +53,7 @@ class TFAdd(keras.layers.Layer):
 
     def call(self, first_operand, second_operand,*args, **kwargs):
         return keras.ops.add(first_operand, second_operand)
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -80,7 +80,7 @@ class TFSub(keras.layers.Layer):
 
     def call(self, first_operand, second_operand,*args, **kwargs):
         return keras.ops.subtract(first_operand, second_operand)
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -107,7 +107,7 @@ class TFMul(keras.layers.Layer):
 
     def call(self, first_operand, second_operand,*args, **kwargs):
         return keras.ops.multiply(first_operand, second_operand)
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -148,7 +148,7 @@ class TFDiv(keras.layers.Layer):
              "second_operand": self.second_operand,
         })
         return config
-    
+
 @OPERATOR.register_operator("Equal")
 class TFEqual(keras.layers.Layer):
     def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
@@ -164,7 +164,7 @@ class TFEqual(keras.layers.Layer):
     def call(self, first_operand, second_operand,*args, **kwargs):
         return keras.ops.equal(first_operand, second_operand)
 
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -193,7 +193,7 @@ class TFLess(keras.layers.Layer):
     def call(self,first_operand, second_operand, *args, **kwargs):
         return keras.ops.less(first_operand, second_operand)
 
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -205,7 +205,7 @@ class TFLess(keras.layers.Layer):
              "second_operand": self.second_operand,
         })
         return config
-    
+
 @OPERATOR.register_operator("Greater")
 class TFGreater(keras.layers.Layer):
     def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
@@ -221,8 +221,8 @@ class TFGreater(keras.layers.Layer):
 
     def call(self,first_operand, second_operand, *args, **kwargs):
         return keras.ops.greater(first_operand, second_operand)
-    
-    
+
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -236,7 +236,7 @@ class TFGreater(keras.layers.Layer):
         })
         return config
 
-    
+
 @OPERATOR.register_operator("Where")
 class TFWhere(keras.layers.Layer):
     def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
@@ -264,7 +264,7 @@ class TFWhere(keras.layers.Layer):
              "false_value": self.false_value
         })
         return config
-    
+
 @OPERATOR.register_operator("Not")
 class TFNot(keras.layers.Layer):
     def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
@@ -287,7 +287,7 @@ class TFNot(keras.layers.Layer):
             'node_attribute':self.node_attribute,
         })
         return config
-    
+
 @OPERATOR.register_operator("And")
 class TFAnd(keras.layers.Layer):
     def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
@@ -298,7 +298,7 @@ class TFAnd(keras.layers.Layer):
         self.node_attribute = node_attribute
     def call(self,  *args, **kwargs):
         return keras.ops.logical_and(args[0], args[1])
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -320,7 +320,7 @@ class TFOr(keras.layers.Layer):
 
     def call(self,  *args, **kwargs):
         return keras.ops.logical_or(args[0], args[1])
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -334,11 +334,26 @@ class TFOr(keras.layers.Layer):
 
 @OPERATOR.register_operator("Abs")
 class TFAbs(keras.layers.Layer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self,tensor_grap,  node_weights, node_inputs, node_attribute, *args, **kwargs):
         super().__init__()
+        self.tensor_grap = tensor_grap
+        self.node_weights = node_weights
+        self.node_inputs = node_inputs
+        self.node_attribute = node_attribute
 
-    def call(self,input,  *args, **kwargs):
-        return keras.ops.absolute(input)
+
+    def call(self,input, *args, **kwargs):
+        return keras.ops.abs(input)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "tensor_grap":self.tensor_grap,
+            'node_weights':self.node_weights,
+            'node_inputs':self.node_inputs,
+            'node_attribute':self.node_attribute,
+        })
+        return config
 
 @OPERATOR.register_operator("Neg")
 class TFNeg(keras.layers.Layer):
@@ -400,7 +415,7 @@ class TFFloor(keras.layers.Layer):
 
     def call(self, inputs, *args, **kwargs):
         return keras.ops.floor(inputs)
-    
+
 @OPERATOR.register_operator("Ceil")
 class TFCeil(keras.layers.Layer):
     def __init__(self, *args, **kwargs):
@@ -474,7 +489,7 @@ class TFReduceSum(keras.layers.Layer):
 
         self.keep_dims = node_attribute.get("keepdims", 1) == 1
         self.axes = node_attribute.get("axes", None)
-       
+
     def call(self, inputs, *args, **kwargs):
         return keras.ops.sum(inputs, axis = self.axes, keepdims=self.keep_dims)
 
@@ -500,10 +515,10 @@ class TFReduceMean(keras.layers.Layer):
 
         self.keep_dims = node_attribute.get("keepdims", 1) == 1
         self.axes = node_attribute.get("axes", None)
-       
+
     def call(self, inputs, *args, **kwargs):
         return keras.ops.mean(inputs, axis = self.axes, keepdims=self.keep_dims)
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -533,7 +548,7 @@ class TFConstantOfShape(keras.layers.Layer):
         self.node_inputs = node_inputs
         self.node_attribute = node_attribute
         self.value = self.node_attribute['value']
-        
+
     def call(self, inputs,*args, **kwargs):
         # print("should be one:::: ", self.node_attribute['value'][0])
         # print('type : ', type(self.node_attribute['value'][0]))
@@ -552,14 +567,14 @@ class TFConstantOfShape(keras.layers.Layer):
         print('shapeyy const size: ', keras.ops.full(inputs.shape, fill_in).shape)
         return keras.ops.full(inputs, fill_in)
 
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
             "tensor_grap":self.tensor_grap,
             'node_weights':self.node_weights,
             'node_inputs':self.node_inputs,
-            'node_attribute':self.node_attribute, 
+            'node_attribute':self.node_attribute,
             'value': self.value
         })
         return config
@@ -580,7 +595,7 @@ class TFMatMul(keras.layers.Layer):
     def call(self,first_operand, second_operand, *args, **kwargs):
         return keras.ops.matmul(first_operand, second_operand)
 
-    
+
     def get_config(self):
         config = super().get_config()
         config.update({
@@ -591,8 +606,8 @@ class TFMatMul(keras.layers.Layer):
              "second_operand": self.second_operand
         })
         return config
-    
-    
+
+
 # TO SUPPORT LATER
 
 # @OPERATOR.register_operator("Pow")
@@ -606,7 +621,7 @@ class TFMatMul(keras.layers.Layer):
 
 #     def call(self, inputs, *args, **kwargs):
 #         return keras.ops.power(inputs, self.power_index)
-    
+
 #     def get_config(self):
 #         config = super().get_config()
 #         config.update({
@@ -648,7 +663,7 @@ class TFMatMul(keras.layers.Layer):
 # class TFErf():
 #     def __init__(self, *args, **kwargs) -> None:
 #         pass
-    
+
 #     def __call__(self, inputs):
 #         inputs = tf.math.erf(inputs)
 #         return inputs

--- a/zkstats/ops.py
+++ b/zkstats/ops.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractclassmethod
+from abc import ABC, abstractmethod
 import statistics
 from typing import Optional
 
@@ -15,14 +15,14 @@ class Operation(ABC):
         self.result = torch.nn.Parameter(data=result, requires_grad=False)
         self.error = error
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def create(cls, x: list[torch.Tensor], error: float) -> 'Operation':
         ...
 
     @abstractmethod
     def ezkl(self, x: list[torch.Tensor]) -> IsResultPrecise:
         ...
-
 
 
 class Mean(Operation):
@@ -80,7 +80,7 @@ class Median(Operation):
             if op_dict is None:
                 super().__init__(torch.tensor(precal_witness['Median_0'][0]), error)
                 self.lower = torch.nn.Parameter(data = torch.tensor(precal_witness['Median_0'][1]), requires_grad=False)
-                self.upper = torch.nn.Parameter(data = torch.tensor(precal_witness['Median_0'][2]), requires_grad=False)             
+                self.upper = torch.nn.Parameter(data = torch.tensor(precal_witness['Median_0'][2]), requires_grad=False)
             elif 'Median' not in op_dict:
                 super().__init__(torch.tensor(precal_witness['Median_0'][0]), error)
                 self.lower = torch.nn.Parameter(data = torch.tensor(precal_witness['Median_0'][1]), requires_grad=False)
@@ -163,7 +163,7 @@ class HarmonicMean(Operation):
                 return cls(torch.tensor(precal_witness['HarmonicMean_0'][0]), error)
             else:
                 return cls(torch.tensor(precal_witness['HarmonicMean_'+str(op_dict['HarmonicMean'])][0]), error)
-     
+
 
     def ezkl(self, x: list[torch.Tensor]) -> IsResultPrecise:
         # Assume x is [1, n, 1]
@@ -234,7 +234,7 @@ class Mode(Operation):
                 return cls(torch.tensor(precal_witness['Mode_0'][0]), error)
             else:
                 return cls(torch.tensor(precal_witness['Mode_'+str(op_dict['Mode'])][0]), error)
-     
+
 
     def ezkl(self, x: list[torch.Tensor]) -> IsResultPrecise:
         # Assume x is [1, n, 1]
@@ -368,7 +368,7 @@ class Variance(Operation):
         else:
             if op_dict is None:
                 super().__init__(torch.tensor(precal_witness['Variance_0'][0]), error)
-                self.data_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Variance_0'][1]), requires_grad=False)         
+                self.data_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Variance_0'][1]), requires_grad=False)
             elif 'Variance' not in op_dict:
                 super().__init__(torch.tensor(precal_witness['Variance_0'][0]), error)
                 self.data_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Variance_0'][1]), requires_grad=False)
@@ -396,7 +396,7 @@ class Variance(Operation):
 
 class Covariance(Operation):
     def __init__(self, x: torch.Tensor, y: torch.Tensor, error: float,  precal_witness:Optional[dict] = None, op_dict:Optional[dict[str,int]] = None):
-        if precal_witness is None: 
+        if precal_witness is None:
             x_1d = to_1d(x)
             x_1d = x_1d[x_1d!=MagicNumber]
             y_1d = to_1d(y)
@@ -413,7 +413,7 @@ class Covariance(Operation):
             if op_dict is None:
                 super().__init__(torch.tensor(precal_witness['Covariance_0'][0]), error)
                 self.x_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Covariance_0'][1]), requires_grad=False)
-                self.y_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Covariance_0'][2]), requires_grad=False)  
+                self.y_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Covariance_0'][2]), requires_grad=False)
             elif 'Covariance' not in op_dict:
                 super().__init__(torch.tensor(precal_witness['Covariance_0'][0]), error)
                 self.x_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Covariance_0'][1]), requires_grad=False)
@@ -479,7 +479,7 @@ class Correlation(Operation):
                 self.y_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Correlation_0'][2]), requires_grad=False)
                 self.x_std = torch.nn.Parameter(data = torch.tensor(precal_witness['Correlation_0'][3]), requires_grad=False)
                 self.y_std = torch.nn.Parameter(data = torch.tensor(precal_witness['Correlation_0'][4]), requires_grad=False)
-                self.cov = torch.nn.Parameter(data = torch.tensor(precal_witness['Correlation_0'][5]), requires_grad=False)       
+                self.cov = torch.nn.Parameter(data = torch.tensor(precal_witness['Correlation_0'][5]), requires_grad=False)
             elif 'Correlation' not in op_dict:
                 super().__init__(torch.tensor(precal_witness['Correlation_0'][0]), error)
                 self.x_mean = torch.nn.Parameter(data = torch.tensor(precal_witness['Correlation_0'][1]), requires_grad=False)
@@ -553,7 +553,7 @@ class Regression(Operation):
             #     precal_witness_arr.append(torch.tensor(ele))
             # print('resultopppp: ', result)
             super().__init__(result,error)
-            
+
 
     @classmethod
     def create(cls, args: list[torch.Tensor], error: float, precal_witness:Optional[dict] = None, op_dict:Optional[dict[str,int]] = None) -> 'Regression':


### PR DESCRIPTION
## What's wrong?
Witness approach used in ZKStats lib does not work with MPC, since no one has the complete witness.

## How to fix it?
- Let user use the same interface with both ZK and MPC
  - Add a `MPCState` conforming the interface `IState`
  - Make the original `State` conform to the interface `IState`
- Implemented MPC logics in `MPCState`. `MPCState` can reuse code from the `ops.py` ofc.

-----
Edited: made `mean` work with tensor resulting from `torch.where`
