### PR TITLE
size, index, cat w/o dimension yet

### DIFF
--- a/tests/onnx2circom/test_size_index_concat.py
+++ b/tests/onnx2circom/test_size_index_concat.py
@@ -1,0 +1,98 @@
+import torch
+import torch.nn as nn
+
+import pytest
+
+from .utils import compile_and_run_mpspdz, run_torch_model
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(lambda x : x+x.size()[0], id="x+size"),
+        pytest.param(lambda x : torch.sum(x)+x.size()[0], id="sum+size"),
+        pytest.param(lambda x : x[0], id="array indexing"),
+        pytest.param(lambda x : x+x[0][0], id="array indexing"),
+    ]
+)
+def test_size_index(func, tmp_path):
+    data = torch.tensor(
+        [-22, -8, 8],
+        dtype = torch.float32,
+    ).reshape( -1,1)
+    data2 = torch.tensor(
+        [1, 13 ],
+        dtype = torch.float32,
+    ).reshape( -1,1)
+    class Model(nn.Module):
+        def forward(self, x ):
+            return func(x)
+
+    # Run the model directly with torch
+    output_torch = run_torch_model(Model, tuple([data]))
+    # Compile and run the model with MP-SPDZ
+    outputs_mpspdz = compile_and_run_mpspdz(Model, tuple([data]), tmp_path)
+    # The model only has one output tensor
+    assert len(outputs_mpspdz) == 1, f"Expecting only one output tensor, but got {len(outputs_mpspdz)} tensors."
+    # Compare the output tensor with the expected output. Different should be within 0.001
+    assert torch.allclose(outputs_mpspdz[0], output_torch, rtol=0.001), f"Output tensor is not close to the expected output tensor. {outputs_mpspdz[0]=}, {output_torch=}"
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(lambda x,y : y+x.size()[0], id="y+ xsize"),
+        pytest.param(lambda x,y : y.size()[0]+x.size()[0], id="xsize+ysize"),
+        pytest.param(lambda x,y  : x[2][0]+y[1][0], id="array indexing"),
+    ]
+)
+def test_size_index_two_inputs(func, tmp_path):
+    data = torch.tensor(
+        [-22, -8, 8],
+        dtype = torch.float32,
+    ).reshape( -1,1)
+    data2 = torch.tensor(
+        [1, 13 ],
+        dtype = torch.float32,
+    ).reshape( -1,1)
+    class Model(nn.Module):
+        def forward(self, x, y ):
+            return func(x,y)
+
+    # Run the model directly with torch
+    output_torch = run_torch_model(Model, tuple([data, data2]))
+    # Compile and run the model with MP-SPDZ
+    outputs_mpspdz = compile_and_run_mpspdz(Model, tuple([data, data2]), tmp_path)
+    # The model only has one output tensor
+    assert len(outputs_mpspdz) == 1, f"Expecting only one output tensor, but got {len(outputs_mpspdz)} tensors."
+    # Compare the output tensor with the expected output. Different should be within 0.001
+    assert torch.allclose(outputs_mpspdz[0], output_torch, rtol=0.001), f"Output tensor is not close to the expected output tensor. {outputs_mpspdz[0]=}, {output_torch=}"
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(lambda x,y : torch.cat((x,y)), id="concat x and y with dim =0"),
+    ]
+)
+def test_cat_two_inputs(func, tmp_path):
+    data = torch.tensor(
+        [-22, -8, 8],
+        dtype = torch.float32,
+    ).reshape( -1,1)
+    data2 = torch.tensor(
+        [1, 13 ],
+        dtype = torch.float32,
+    ).reshape( -1,1)
+    class Model(nn.Module):
+        def forward(self, x, y ):
+            return func(x,y)
+
+    # Run the model directly with torch
+    output_torch = run_torch_model(Model, tuple([data, data2]))
+    # Compile and run the model with MP-SPDZ
+    outputs_mpspdz = compile_and_run_mpspdz(Model, tuple([data, data2]), tmp_path)
+    # The model only has one output tensor
+    assert len(outputs_mpspdz) == 1, f"Expecting only one output tensor, but got {len(outputs_mpspdz)} tensors."
+    # Compare the output tensor with the expected output. Different should be within 0.001
+    assert torch.allclose(outputs_mpspdz[0], output_torch, rtol=0.001), f"Output tensor is not close to the expected output tensor. {outputs_mpspdz[0]=}, {output_torch=}"

--- a/zkstats/onnx2circom/keras2circom/keras2circom/model.py
+++ b/zkstats/onnx2circom/keras2circom/keras2circom/model.py
@@ -66,20 +66,20 @@ class Layer:
                 # if it's keras tensor resulting in constant, get the shape from non-constant input
                 if input_shape == ():
                     # if there are more than 1 inputs like `TFAdd`, we need to get the shape of the other input
-                    if len(_inputs)==2 and len(_inputs[1-index].shape)>=2:
-                        input_shape = (_inputs[1-index]).shape[:-1]
+                    if len(_inputs)==2 and len(_inputs[1-index].shape)>=1:
+                        input_shape = (_inputs[1-index]).shape
                     else:
-                        input_shape =(1,1)
+                        input_shape =(1,)
                     is_keras_constant = True
                 index += 1
             # it's constant. assume it's a float
             else:
                 name = None
                 value = float(config_ele)
-                if len(_inputs)>0 and len(_inputs[0].shape)>=2:
-                    input_shape = (_inputs[0]).shape[:-1]
+                if len(_inputs)>0 and len(_inputs[0].shape)>=1:
+                    input_shape = (_inputs[0]).shape
                 else:
-                    input_shape =(1,1)
+                    input_shape =(1,)
                 
             self.inputs.append(
                 Input(
@@ -121,8 +121,8 @@ class Model:
                 if output.name in self.map_output_to_component:
                     raise ValueError(f"Output name {output.name} is already used by another layer.")
                 self.map_output_to_component[output.name] = layer
-        print('\n\n\n\n\n MPAPPPA: ', self.map_output_to_component.keys())
-        print('\n\n\n\n\n\n')
+        # print('\n\n\n\n\n MPAPPPA: ', self.map_output_to_component.keys())
+        # print('\n\n\n\n\n\n')
     def get_component_from_output_name(self, output_name: str) -> typing.Optional[Layer]:
         try:
             return self.map_output_to_component[output_name]

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -139,6 +139,34 @@ template TFReduceSum(nInputs) {
     out <== sum_till[nInputs-1] + 0;
 }
 
+template TFReduceMax(nInputs) {
+    signal input in[nInputs];
+    signal output out;
+
+    signal max_till[nInputs];
+    max_till[0] <== in[0];
+    for (var i = 0; i<nInputs-1; i++){
+        max_till[i+1] <== max_till[i] + (in[i+1]-max_till[i])*(in[i+1]>max_till[i]);
+    }
+    // FIXME: adding 0 is a workaround for nInputs=1, to force `in[0][0]` to be an
+    // input in a gate
+    out <== max_till[nInputs-1] + 0;
+}
+
+template TFReduceMin(nInputs) {
+    signal input in[nInputs];
+    signal output out;
+
+    signal min_till[nInputs];
+    min_till[0] <== in[0];
+    for (var i = 0; i<nInputs-1; i++){
+        min_till[i+1] <== min_till[i] + (in[i+1]-min_till[i])*(in[i+1]<min_till[i]);
+    }
+    // FIXME: adding 0 is a workaround for nInputs=1, to force `in[0][0]` to be an
+    // input in a gate
+    out <== min_till[nInputs-1] + 0;
+}
+
 template TFReduceMean(nInputs) {
     signal input in[nInputs];
     signal output out;
@@ -238,5 +266,32 @@ template TFLog(e, nInputs) {
         taylor_series_sum[input_index] <== taylor_series_sum_comp[input_index].out;
 
         out[input_index] <== taylor_series_sum[input_index] + k[input_index];
+    }
+}
+
+template TFGather(nElements) {
+    signal input in[nElements];
+    signal input index;
+    signal output out;
+    signal out_till[nElements+1];
+
+    out_till[0] <== 0;
+    for (var i = 0; i< nElements; i++){
+        out_till[i+1] <== out_till[i] + (index==i)*in[i];
+    }
+
+    out <== out_till[nElements];
+    
+}
+
+template TFConcat(nElements_0, nElements_1){
+    signal input in_0[nElements_0];
+    signal input in_1[nElements_1];
+    signal output out[nElements_0+nElements_1];
+    for (var i = 0; i< nElements_0; i++){
+        out[i] <== in_0[i]+0;
+    }
+    for (var i = 0; i< nElements_1; i++){
+        out[nElements_0+i] <== in_1[i]+0;
     }
 }


### PR DESCRIPTION
Implement Size, Gather, Concat in a limited way that supports
-x.size()[0], x.size()[1], etc.
-Getting a certain number out of array i.e. X[0][0]
-Concat two tensor horizontally: [1,3,4] concat [4,3,2] --> [1,3,4,4,3,2]

This doesn't cover edge case like concat vertically (torch.cat(dim = 1) yet). Or to make circom template that realizes that Given 2D X, X[0] should be 1D array. Now we just treat X[0] as just one value since we know that all our tensors are in shape (-1,1) anyway. This should work fine for all zk-stats supported operations but can cause problem for Regression, which has something like torch.cat((*args[:-1], torch.ones_like(args[0])), dim = 1)

I think to really make circom template truly reflect the shape of keras tensor, we need to change every of our template now , for example in mpc.circom, rn TFEqual, TFGreater, etc. just considers the signal input as 1D instead of 2D. If we really want to make array indexing X[0] really represents 1D array, we need to adjust those templates as well. 

My suggestion is to try implement every function with this dimension-ignorant approach first, and we can see what's the best way to make it work for Regression later on. lemme know what u think @mhchia 

