### PR TITLE
Remove note on ubuntu 22.04 section

### DIFF
--- a/tests/onnx2circom/README.md
+++ b/tests/onnx2circom/README.md
@@ -22,9 +22,6 @@ On macOS, installing `brew` is sufficient.
 
 For other platforms, refer to the [TL;DR (Source Distribution)](https://github.com/data61/MP-SPDZ?tab=readme-ov-file#tldr-source-distribution) section of the MP-SPDZ README file.
 
-#### Note on Ubuntu 22.04
-In addition to the libraries mentioned in the MP-SPDZ README file, `libboost-iostreams-dev` package is needed.
-
 ## Test onnx2keras
 
 Run the test:


### PR DESCRIPTION
MP-SPDZ README has been updated to add `libboost-iostreams-dev` to the list of Ubuntu required packages, therefore the section should be droped now.