### PR TITLE
[Unfinished] JOIN for mpcstats

### DIFF
--- a/tests/onnx2circom/test_zkstats_computation.py
+++ b/tests/onnx2circom/test_zkstats_computation.py
@@ -1,26 +1,62 @@
 import torch
 from typing import Type
 
-from zkstats.computation import IState, computation_to_model_mpc
+from zkstats.computation import IState, computation_to_model_mpc, MagicNumber
 
 from .utils import compile_and_run_mpspdz
 
 
-
 def computation(state: IState, args: list[torch.Tensor]):
-    x = args[0]
-    # y = args[1]
-    # z = args[2]
-    return state.mean(x)
+    columns_0 = [args[0], args[1]]
+    columns_1 = [args[2], args[3]]
+    x_key = columns_0[0]
+    y_key = columns_1[0]
+    num_rows_x = x_key.size(0)
+    num_cols_y = len(columns_1)
+
+    # Create a tensor for each new y columns
+    new_y = [torch.where(x_key == 0, 0, 0) for _ in columns_1]
+    for i in range(num_rows_x):
+        # i = 0, one_hot = [1, 0, 0, 0]
+        # i = 1, one_hot = [0, 1, 0, 0]
+        one_hot = torch.arange(num_rows_x) == i
+        # new_y[i] = 1
+        # [1, 4] -> [0, 1]
+        mask = y_key == x_key[i]
+        # is_mask_nonzero = torch.sum(mask) != 0
+        for k in range(num_cols_y):
+            # [0, 1] * [5, 4] -> [0, 4]
+            # sum([0, 4]) -> 4
+            matched_value = torch.sum(mask * columns_1[k])
+            # [1, 0, 0, 0] * 4 -> [4, 0, 0, 0]
+            entry = one_hot * matched_value
+            new_y[k] = entry + new_y[k]
+            # new_y[k][i] = matched_value + new_y[k][i]
+    return list(columns_0) + [torch.where(col == 0, MagicNumber, col) for col in new_y]
 
 
 # two tensor stuffs
 def test_computation(tmp_path):
-    data_1 = torch.tensor(
-        [32, 8, 8],
+    x_0 = torch.tensor(
+        [1, 2, 3],
+        dtype = torch.float32,
+    ).reshape(-1, 1)
+    x_1 = torch.tensor(
+        [180, 160, 183],
+        dtype = torch.float32,
+    ).reshape(-1, 1)
+    y_0 = torch.tensor(
+        [1, 2, 4],
+        dtype = torch.float32,
+    ).reshape(-1, 1)
+    y_1 = torch.tensor(
+        [50, 40, 75],
         dtype = torch.float32,
     ).reshape(-1, 1)
 
+    data = (x_0, x_1, y_0, y_1)
+
     state, Model = computation_to_model_mpc(computation)
 
-    compile_and_run_mpspdz(Model, tuple([data_1]), tmp_path)
+    res = compile_and_run_mpspdz(Model, data, tmp_path)
+    print(f"!@# res={res}")

--- a/tests/onnx2circom/utils.py
+++ b/tests/onnx2circom/utils.py
@@ -12,12 +12,12 @@ from zkstats.arithc_to_bristol import parse_arithc_json
 from zkstats.backends.mpspdz import generate_mpspdz_circuit, generate_mpspdz_inputs_for_party, run_mpspdz_circuit, tensors_to_circom_mpspdz_inputs
 
 
-CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/path/to/circom-2-arithc-project-root')
-MP_SPDZ_PROJECT_ROOT = Path('/path/to/mp-spdz-project-root')
+CIRCOM_2_ARITHC_PROJECT_ROOT = Path('/Users/mhchia/projects/work/pse/circom-2-arithc')
+MP_SPDZ_PROJECT_ROOT = Path('/Users/mhchia/projects/work/pse/MP-SPDZ')
 
 #  For generalized multiple tensor input
 
-def compile_and_run_mpspdz(model_type: Type[nn.Module], data: tuple[torch.Tensor], tmp_path: Path):
+def compile_and_run_mpspdz(model_type: Type[nn.Module], data: tuple[torch.Tensor, ...], tmp_path: Path):
     # output_path = tmp_path
     # Don't use tmp_path for now for easier debugging
     # So you should see all generated files in `output_path`
@@ -161,7 +161,7 @@ def run_torch_model(model_type: Type[nn.Module], data: tuple[torch.Tensor]) -> t
         return output_torch.reshape(-1)
 
 
-def torch_model_to_onnx(model_type: Type[nn.Module], data: tuple[torch.Tensor], output_onnx_path: Path):
+def torch_model_to_onnx(model_type: Type[nn.Module], data: tuple[torch.Tensor, ...], output_onnx_path: Path):
   model = model_type()
   input_names = []
 #   dynamic_axes = {}

--- a/zkstats/onnx2circom/mpc.circom
+++ b/zkstats/onnx2circom/mpc.circom
@@ -281,7 +281,7 @@ template TFGather(nElements) {
     }
 
     out <== out_till[nElements];
-    
+
 }
 
 template TFConcat(nElements_0, nElements_1){
@@ -293,5 +293,13 @@ template TFConcat(nElements_0, nElements_1){
     }
     for (var i = 0; i< nElements_1; i++){
         out[nElements_0+i] <== in_1[i]+0;
+    }
+}
+
+template TFIdentity(nElements) {
+    signal input in[nElements];
+    signal output out[nElements];
+    for (var i = 0; i<nElements; i++){
+        out[i] <== in[i] + 0;
     }
 }


### PR DESCRIPTION
## What's done?
- torch implementation for `join(columns_0: list[torch.Tensor], columns_1: list[torch.Tensor], index_0: int, index_1: int) -> list[torch.Tensor]`


## What hasn't been done?
- make keras2circom work with torch.join
  - it's not working at the moment since 1d array constants in torch is not supported (but required in the join implementation in torch.