### PR TITLE
fix: outputs order is wrong when more than 1 outputs

### DIFF
--- a/zkstats/computation.py
+++ b/zkstats/computation.py
@@ -248,6 +248,8 @@ class State:
             if current_op_index > len_ops - 1:
                 # Sanity check that current op index does not exceed the length of ops
                 raise Exception(f"current_op_index out of bound: {current_op_index=} > {len_ops=}")
+            if self.isProver:
+                json.dump(self.precal_witness, open(self.precal_witness_path, 'w'))
             return op.result+(x[0]-x[0])[0][0]
 
 


### PR DESCRIPTION
## What's wrong?
With computation returning more than 1 outputs, we get the wrong order of outputs. For example, the computation like this
```python
def computation(state: State, args: list[torch.Tensor]):
    x = args[0]
    y = args[1]
    return state.mean(x), state.median(y)
```
results in outputs like
```
51.5, 1, 46.25
```
where `1` is the boolean for verifiers to check the result is accurate enough. It is wrong since `1` should always be the first return value of a computation

The issue is that we return `is_precise_aggregated, op.result+(x[0]-x[0])[0][0]` for the last operation. However, the return value of a computation is not necessarily the return value of the last operation. For example,
```python
def computation(state: State, args: list[torch.Tensor]):
    x = args[0]
    y = args[1]
    return state.mean(x), state.median(y)
```
the last operation is `state.median(y)` but the return value is `state.mean(x), state.median(y)`. In our original approach, we'll return `res_mean, is_precise_aggregated,  res_median`. 

## How it's fixed?
Instead of returning the `is_precise_aggregated` in State.call_ops, we do it in the `Model.forward`

```python
def forward(self, *x: list[torch.Tensor]) -> tuple[IsResultPrecise, torch.Tensor]:
            result = computation(state, x)
            is_computation_result_accurate = state.bools[0]()
            for op_precise_check in state.bools[1:]:
                is_op_result_accurate = op_precise_check()
                is_computation_result_accurate = torch.logical_and(is_computation_result_accurate, is_op_result_accurate)
            return is_computation_result_accurate, result
```
