### PR TITLE
use key to access column in computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ def user_computation(s: State, data: list[torch.Tensor]) -> torch.Tensor:
 For example, we have two columns of data and we want to compute the mean of the medians of the two columns:
 
 ```python
-def user_computation(s: State, data: list[torch.Tensor]) -> torch.Tensor:
+def user_computation(s: State, data: Args) -> torch.Tensor:
     # Compute the median of the first column
-    median1 = s.median(data[0])
+    median1 = s.median(data['column1'])
     # Compute the median of the second column
-    median2 = s.median(data[1])
+    median2 = s.median(data['column2'])
     # Compute the mean of the medians
     return s.mean(torch.cat((median1.unsqueeze(0), median2.unsqueeze(0))).reshape(1,-1,1))
 ```
@@ -74,9 +74,9 @@ TODO: We should have a list for all supported PyTorch functions.
 Although we cannot filter data into any arbitrary shape using just condition + index (e.g. `X[X > 0]`), we implemented State.where operation that allows users to filter data by their own choice of condition as follows.
 
 ```python
-def user_computation(s: State, data: list[torch.Tensor]) -> torch.Tensor:
+def user_computation(s: State, data: Args) -> torch.Tensor:
     # Compute the mean of the absolute values
-    x = data[0]
+    x = data['x']
     # Here condition can be chained as shown below, and can have many variables if we have more than just x: e.g. filter = torch.logical_and(x>20, y<2) in case of regression for example.
     filter  = torch.logical_and(x > 20, x<50)
     # call our where function
@@ -116,9 +116,9 @@ Note here, that we can also just let prover generate model, and then send that m
 ```python
 from zkstats.core import computation_to_model
 # For prover: generate prover_model, and write to precal_witness file
-_, prover_model = computation_to_model(user_computation, precal_witness_path, True, error)
+_, prover_model = computation_to_model(user_computation, precal_witness_path, True, selected_columns, error)
 # For verifier, generate verifier model (which is same as prover_model) by reading precal_witness file
-_, verifier_model = computation_to_model(user_computation, precal_witness_path, False, error)
+_, verifier_model = computation_to_model(user_computation, precal_witness_path, False, selected_columns, error)
 ```
 
 #### Data Provider: generate settings

--- a/examples/1.only_torch/only_torch.ipynb
+++ b/examples/1.only_torch/only_torch.ipynb
@@ -181,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/2.torch+state/torch+state.ipynb
+++ b/examples/2.torch+state/torch+state.ipynb
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/3.state/state.ipynb
+++ b/examples/3.state/state.ipynb
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/correlation/correlation.ipynb
+++ b/examples/correlation/correlation.ipynb
@@ -157,7 +157,7 @@
     "\n",
     "error = 0.01\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/covariance/covariance.ipynb
+++ b/examples/covariance/covariance.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "error = 0.01\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -163,7 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/geomean/geomean.ipynb
+++ b/examples/geomean/geomean.ipynb
@@ -154,7 +154,7 @@
     "    return s.geometric_mean(x)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)"
    ]
   },
@@ -164,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/harmomean/harmomean.ipynb
+++ b/examples/harmomean/harmomean.ipynb
@@ -150,7 +150,7 @@
     "error = 0.1\n",
     "\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/mean/mean.ipynb
+++ b/examples/mean/mean.ipynb
@@ -166,7 +166,7 @@
     "\n",
     "\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -186,7 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/median/median.ipynb
+++ b/examples/median/median.ipynb
@@ -154,7 +154,7 @@
     "# error here in Median only matters in determining the median value in case it doesnt exist in dataset. (Avg of 2 middle values)\n",
     "error = 0.01\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation,precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model,prover_model_path, scales, \"resources\", settings_path)"
    ]
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path, verifier_model, verifier_model_path)"
    ]

--- a/examples/mode/mode.ipynb
+++ b/examples/mode/mode.ipynb
@@ -157,7 +157,7 @@
     "error = 0\n",
     "\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -168,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/pstdev/pstdev.ipynb
+++ b/examples/pstdev/pstdev.ipynb
@@ -135,7 +135,7 @@
     "error = 0.01\n",
     "\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -146,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/pvariance/pvariance.ipynb
+++ b/examples/pvariance/pvariance.ipynb
@@ -135,7 +135,7 @@
     "error = 0.01\n",
     "\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -147,7 +147,7 @@
    "outputs": [],
    "source": [
     "# Prover/ data owner side\n",
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/regression/regression.ipynb
+++ b/examples/regression/regression.ipynb
@@ -142,7 +142,7 @@
     "    return s.linear_regression(x, y)\n",
     "\n",
     "error = 0.05\n",
-    "_, prover_model = computation_to_model(computation,precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model,prover_model_path, scales, \"resources\", settings_path)"
    ]
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path, verifier_model, verifier_model_path)"
    ]

--- a/examples/stdev/stdev.ipynb
+++ b/examples/stdev/stdev.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "error = 0.01\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/variance/variance.ipynb
+++ b/examples/variance/variance.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "error = 0.01\n",
     "# Prover/ data owner side\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+correlation/where+correlation.ipynb
+++ b/examples/where/where+correlation/where+correlation.ipynb
@@ -167,7 +167,7 @@
     "    return s.correlation(filtered_x, filtered_y)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+covariance/where+covariance.ipynb
+++ b/examples/where/where+covariance/where+covariance.ipynb
@@ -159,7 +159,7 @@
     "\n",
     "error = 0.01\n",
     "\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+geomean/where+geomean.ipynb
+++ b/examples/where/where+geomean/where+geomean.ipynb
@@ -159,7 +159,7 @@
     "\n",
     "error = 0.01\n",
     "\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+harmomean/where+harmomean.ipynb
+++ b/examples/where/where+harmomean/where+harmomean.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "error = 0.1\n",
     "\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -163,7 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+mean/where+mean.ipynb
+++ b/examples/where/where+mean/where+mean.ipynb
@@ -145,7 +145,7 @@
     "\n",
     "error = 0.01\n",
     "\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+median/where+median.ipynb
+++ b/examples/where/where+median/where+median.ipynb
@@ -154,7 +154,7 @@
     "    return s.median(filtered_x)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+mode/where+mode.ipynb
+++ b/examples/where/where+mode/where+mode.ipynb
@@ -183,7 +183,7 @@
     "    return s.mode(filtered_x)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+pstdev/where+pstdev.ipynb
+++ b/examples/where/where+pstdev/where+pstdev.ipynb
@@ -149,7 +149,7 @@
     "    return s.pstdev(filtered_x)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n",
     "\n"
    ]
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns,error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+pvariance/where+pvariance.ipynb
+++ b/examples/where/where+pvariance/where+pvariance.ipynb
@@ -149,7 +149,7 @@
     "    return s.pvariance(filtered_x)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns,error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+regression/where+regression.ipynb
+++ b/examples/where/where+regression/where+regression.ipynb
@@ -150,7 +150,7 @@
     "    y = data[1]\n",
     "\n",
     "    filter = (y < 20)\n",
-    "    \n",
+    "\n",
     "    filtered_x = s.where(filter, x)\n",
     "    filtered_y = s.where(filter, y)\n",
     "    return s.linear_regression(filtered_x,filtered_y)\n",
@@ -158,7 +158,7 @@
     "\n",
     "\n",
     "error = 0.05\n",
-    "_, prover_model = computation_to_model(computation, precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation, precal_witness_path, True, selected_columns, error)\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model, prover_model_path, scales, \"resources\", settings_path)\n"
    ]
   },
@@ -168,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False,error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns,error)\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path,verifier_model, verifier_model_path)"
    ]
   },

--- a/examples/where/where+stdev/where+stdev.ipynb
+++ b/examples/where/where+stdev/where+stdev.ipynb
@@ -150,7 +150,7 @@
     "    return s.stdev(filtered_x)\n",
     "\n",
     "error = 0.05\n",
-    "_, prover_model = computation_to_model(computation,precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation,precal_witness_path, True, selected_columns, error)\n",
     "\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model,prover_model_path, scales, \"resources\", settings_path)"
    ]
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path, verifier_model, verifier_model_path)"
    ]

--- a/examples/where/where+variance/where+variance.ipynb
+++ b/examples/where/where+variance/where+variance.ipynb
@@ -149,7 +149,7 @@
     "    return s.variance(filtered_x)\n",
     "\n",
     "error = 0.01\n",
-    "_, prover_model = computation_to_model(computation,precal_witness_path, True, error)\n",
+    "_, prover_model = computation_to_model(computation,precal_witness_path, True, selected_columns, error)\n",
     "\n",
     "prover_gen_settings(data_path, selected_columns, sel_data_path, prover_model,prover_model_path, scales, \"resources\", settings_path)"
    ]
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, error)\n",
+    "_, verifier_model = computation_to_model(computation, precal_witness_path, False, selected_columns, error)\n",
     "\n",
     "verifier_define_calculation(dummy_data_path, selected_columns, sel_dummy_data_path, verifier_model, verifier_model_path)"
    ]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import torch
 
-from zkstats.core import create_dummy,prover_gen_settings, setup, prover_gen_proof, verifier_verify, generate_data_commitment, verifier_define_calculation
-from zkstats.computation import IModel, State, computation_to_model
+from zkstats.core import prover_gen_settings, setup, prover_gen_proof, verifier_verify, generate_data_commitment, verifier_define_calculation
+from zkstats.computation import computation_to_model, TComputation, State, IModel
 
 
 DEFAULT_POSSIBLE_SCALES = list(range(20))
@@ -27,16 +27,15 @@ def data_to_json_file(data_path: Path, data: list[torch.Tensor]) -> dict[str, li
         json.dump(column_to_data, f)
     return column_to_data
 
-TComputation = Callable[[State, list[torch.Tensor]], torch.Tensor]
-def compute(
+
+
+def compute_model(
     basepath: Path,
     data: list[torch.Tensor],
-    model: Type[IModel],
-    # computation: TComputation,
+    model: IModel,
     scales_params: Optional[Sequence[int]] = None,
     selected_columns_params: Optional[list[str]] = None,
-    # error:float = 1.0
-) -> None:
+):
     sel_data_path = basepath / "comb_data.json"
     model_path = basepath / "model.onnx"
     settings_path = basepath / "settings.json"
@@ -65,12 +64,12 @@ def compute(
         scales_for_commitments = scales_params
     # create_dummy((data_path), (dummy_data_path))
     generate_data_commitment((data_path), scales_for_commitments, (data_commitment_path))
-    # _, prover_model = computation_to_model(computation, (precal_witness_path), True, error)
+    # _, prover_model = computation_to_model(computation, (precal_witness_path), True, selected_columns, error)
 
     prover_gen_settings((data_path), selected_columns, (sel_data_path), model, (model_path), scales, "resources", (settings_path))
 
     # No need, since verifier & prover share the same onnx
-    # _, verifier_model = computation_to_model(computation, (precal_witness_path), False,error)
+    # _, verifier_model = computation_to_model(computation, (precal_witness_path), False, selected_columns, error)
     # verifier_define_calculation((dummy_data_path), selected_columns, (sel_dummy_data_path),verifier_model, (verifier_model_path))
 
     setup((model_path), (compiled_model_path), (settings_path),(vk_path), (pk_path ))
@@ -78,6 +77,29 @@ def compute(
     prover_gen_proof((model_path), (sel_data_path), (witness_path), (compiled_model_path), (settings_path), (proof_path), (pk_path))
     # print('slett col: ', selected_columns)
     verifier_verify((proof_path), (settings_path), (vk_path), selected_columns, (data_commitment_path))
+
+
+def compute(
+    basepath: Path,
+    data: list[torch.Tensor],
+    computation: TComputation,
+    scales_params: Optional[Sequence[int]] = None,
+    selected_columns_params: Optional[list[str]] = None,
+) -> State:
+    data_path = basepath / "data.json"
+    precal_witness_path = basepath / "precal_witness_path.json"
+
+    column_to_data = data_to_json_file(data_path, data)
+    # If selected_columns_params is None, select all columns
+    if selected_columns_params is None:
+        selected_columns = list(column_to_data.keys())
+    else:
+        selected_columns = selected_columns_params
+
+    state, model = computation_to_model(computation, precal_witness_path, True, selected_columns, selected_columns)
+    compute_model(basepath, data, model, scales_params, selected_columns_params)
+    return state
+
 
 
 # Error tolerance between zkstats python implementation and python statistics module

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -7,7 +7,7 @@ import torch
 from zkstats.ops import Mean, Median, GeometricMean, HarmonicMean, Mode, PStdev, PVariance, Stdev, Variance, Covariance, Correlation, Operation, Regression
 from zkstats.computation import IModel, IsResultPrecise, State, computation_to_model
 
-from .helpers import compute, assert_result, ERROR_CIRCUIT_DEFAULT, ERROR_CIRCUIT_STRICT, ERROR_CIRCUIT_RELAXED
+from .helpers import compute_model, assert_result, ERROR_CIRCUIT_DEFAULT, ERROR_CIRCUIT_STRICT, ERROR_CIRCUIT_RELAXED
 
 
 @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ def test_linear_regression(tmp_path, column_0: torch.Tensor, column_1: torch.Ten
     class Model(IModel):
         def forward(self, *x: list[torch.Tensor]) -> tuple[IsResultPrecise, torch.Tensor]:
             return regression.ezkl(x), regression.result
-    compute(tmp_path, columns, Model, scales)
+    compute_model(tmp_path, columns, Model, scales)
 
 
 
@@ -70,4 +70,4 @@ def run_test_ops(tmp_path, op_type: Type[Operation], expected_func: Callable[[li
     class Model(IModel):
         def forward(self, *x: list[torch.Tensor]) -> tuple[IsResultPrecise, torch.Tensor]:
             return op.ezkl(x), op.result
-    compute(tmp_path, columns, Model, scales)
+    compute_model(tmp_path, columns, Model, scales)


### PR DESCRIPTION
Columns are accessed through their column name. E.g.
```python
def user_computation(s: State, data: Args) -> torch.Tensor:
    # Compute the median of the first column
    median1 = s.median(data['column1'])
    median2 = s.median(data['column2'])
    return s.mean(torch.cat((median1.unsqueeze(0), median2.unsqueeze(0))).reshape(1,-1,1))
```